### PR TITLE
Add single-city confirmation on Select City

### DIFF
--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/city/CityInteractor.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/city/CityInteractor.kt
@@ -11,7 +11,8 @@ class CityInteractor(
 ) : ICityInteractor {
     override suspend fun getCityList(): List<City>? = cityRepo.getCityList().ifEmpty { null }
 
-    override suspend fun checkIsCitySelected(): Boolean = cityRepo.getSelectedCityUuid() != null
+    override suspend fun checkIsCitySelected(): Boolean =
+        !cityRepo.getSelectedCityUuid().isNullOrBlank()
 
     override suspend fun saveSelectedCity(city: City) {
         cityRepo.saveSelectedCityUuid(cityUuid = city.uuid)

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/splash/CheckOneCityUseCase.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/splash/CheckOneCityUseCase.kt
@@ -1,11 +1,14 @@
 package com.bunbeauty.core.domain.splash
 
 import com.bunbeauty.core.domain.repo.CityRepo
+import com.bunbeauty.core.model.city.City
 
 private const val ONE_CITY_COUNT = 1
 
 class CheckOneCityUseCase(
     private val cityRepo: CityRepo,
 ) {
-    suspend operator fun invoke(): Boolean = cityRepo.getCityList().size == ONE_CITY_COUNT
+    suspend operator fun invoke(): Boolean = invoke(cityList = cityRepo.getCityList())
+
+    operator fun invoke(cityList: List<City>): Boolean = cityList.size == ONE_CITY_COUNT
 }

--- a/designsystem/src/commonMain/composeResources/drawable/ic_select_city_location.xml
+++ b/designsystem/src/commonMain/composeResources/drawable/ic_select_city_location.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64dp"
+    android:height="64dp"
+    android:viewportWidth="120"
+    android:viewportHeight="120">
+  <path
+      android:pathData="M60.408,62.231C65.359,62.231 69.372,58.236 69.372,53.308C69.372,48.38 65.359,44.385 60.408,44.385C55.458,44.385 51.444,48.38 51.444,53.308C51.444,58.236 55.458,62.231 60.408,62.231Z"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"/>
+  <path
+      android:pathData="M82.818,53.308C82.818,73.385 60.409,89 60.409,89C60.409,89 38,73.385 38,53.308C38,47.391 40.361,41.717 44.564,37.534C48.766,33.35 54.466,31 60.409,31C66.352,31 72.052,33.35 76.255,37.534C80.457,41.717 82.818,47.391 82.818,53.308V53.308Z"
+      android:strokeWidth="6"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"/>
+</vector>

--- a/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -42,6 +42,9 @@
     <!-- SELECT CITY -->
     <string name="title_select_city">Выбор города</string>
     <string name="error_select_city_loading">Не удалось загрузить список городов</string>
+    <string name="msg_select_city_single_city_available">Заказы доступны в одном городе:</string>
+    <string name="action_select_city_continue">Продолжить</string>
+    <string name="description_select_city_location">Город доставки</string>
 
     <!-- UPDATE -->
     <string name="title_update_new_app_version">Новая версия</string>

--- a/designsystem/src/commonMain/kotlin/com/bunbeauty/designsystem/ui/element/button/MainButton.kt
+++ b/designsystem/src/commonMain/kotlin/com/bunbeauty/designsystem/ui/element/button/MainButton.kt
@@ -1,14 +1,12 @@
 package com.bunbeauty.designsystem.ui.element.button
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.bunbeauty.designsystem.theme.FoodDeliveryTheme
 import com.bunbeauty.designsystem.theme.medium
-import com.bunbeauty.designsystem.ui.LocalBottomBarPadding
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview

--- a/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/presentation/selectcity/SelectCityDataState.kt
+++ b/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/presentation/selectcity/SelectCityDataState.kt
@@ -9,11 +9,17 @@ interface SelectCityDataState {
     data class DataState(
         val state: State,
         val cityList: List<City> = emptyList(),
+        val contentMode: ContentMode = ContentMode.CityList,
     ) : BaseDataState {
         enum class State {
             LOADING,
             SUCCESS,
             ERROR,
+        }
+
+        enum class ContentMode {
+            CityList,
+            SingleCity,
         }
     }
 
@@ -23,6 +29,8 @@ interface SelectCityDataState {
         data class OnCitySelected(
             val city: City,
         ) : Action
+
+        data object OnContinueClicked : Action
 
         data object GetCityList : Action
     }

--- a/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/presentation/selectcity/SelectCityViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/presentation/selectcity/SelectCityViewModel.kt
@@ -32,7 +32,13 @@ class SelectCityViewModel(
         setState { copy(state = SelectCityDataState.DataState.State.LOADING) }
         sharedScope.launchSafe(
             block = {
-                val cities = cityInteractor.getCityList() ?: emptyList()
+                val cities = cityInteractor.getCityList().orEmpty()
+                if (cities.isEmpty()) {
+                    setState {
+                        copy(state = SelectCityDataState.DataState.State.ERROR)
+                    }
+                    return@launchSafe
+                }
                 val contentMode =
                     if (checkOneCityUseCase(cities)) {
                         SelectCityDataState.DataState.ContentMode.SingleCity

--- a/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/presentation/selectcity/SelectCityViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/presentation/selectcity/SelectCityViewModel.kt
@@ -2,11 +2,13 @@ package com.bunbeauty.profile.presentation.selectcity
 
 import com.bunbeauty.core.base.SharedStateViewModel
 import com.bunbeauty.core.domain.city.ICityInteractor
+import com.bunbeauty.core.domain.splash.CheckOneCityUseCase
 import com.bunbeauty.core.extension.launchSafe
 import com.bunbeauty.core.model.city.City
 
 class SelectCityViewModel(
     private val cityInteractor: ICityInteractor,
+    private val checkOneCityUseCase: CheckOneCityUseCase,
 ) : SharedStateViewModel<SelectCityDataState.DataState, SelectCityDataState.Action, SelectCityDataState.Event>(
         initDataState =
             SelectCityDataState.DataState(
@@ -20,6 +22,7 @@ class SelectCityViewModel(
     ) {
         when (action) {
             is SelectCityDataState.Action.OnCitySelected -> onCitySelected(city = action.city)
+            SelectCityDataState.Action.OnContinueClicked -> onContinueClicked(dataState = dataState)
             SelectCityDataState.Action.OnRefreshClicked -> getCityList()
             SelectCityDataState.Action.GetCityList -> getCityList()
         }
@@ -29,10 +32,18 @@ class SelectCityViewModel(
         setState { copy(state = SelectCityDataState.DataState.State.LOADING) }
         sharedScope.launchSafe(
             block = {
+                val cities = cityInteractor.getCityList() ?: emptyList()
+                val contentMode =
+                    if (checkOneCityUseCase(cities)) {
+                        SelectCityDataState.DataState.ContentMode.SingleCity
+                    } else {
+                        SelectCityDataState.DataState.ContentMode.CityList
+                    }
                 setState {
                     copy(
                         state = SelectCityDataState.DataState.State.SUCCESS,
-                        cityList = cityInteractor.getCityList() ?: emptyList(),
+                        cityList = cities,
+                        contentMode = contentMode,
                     )
                 }
             },
@@ -42,6 +53,11 @@ class SelectCityViewModel(
                 }
             },
         )
+    }
+
+    private fun onContinueClicked(dataState: SelectCityDataState.DataState) {
+        val city = dataState.cityList.firstOrNull() ?: return
+        onCitySelected(city = city)
     }
 
     private fun onCitySelected(city: City) {

--- a/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/ui/screen/city/screen/selectcity/SelectCityRoute.kt
+++ b/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/ui/screen/city/screen/selectcity/SelectCityRoute.kt
@@ -1,30 +1,51 @@
 package com.bunbeauty.profile.ui.screen.city.screen.selectcity
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.bunbeauty.core.model.city.City
 import com.bunbeauty.designsystem.theme.FoodDeliveryTheme
+import com.bunbeauty.designsystem.theme.bold
+import com.bunbeauty.designsystem.ui.LocalBottomBarPadding
 import com.bunbeauty.designsystem.ui.element.FoodDeliveryScaffold
+import com.bunbeauty.designsystem.ui.element.button.MainButton
 import com.bunbeauty.designsystem.ui.screen.ErrorScreen
 import com.bunbeauty.designsystem.ui.screen.LoadingScreen
 import com.bunbeauty.profile.presentation.selectcity.SelectCityDataState
 import com.bunbeauty.profile.presentation.selectcity.SelectCityViewModel
 import com.bunbeauty.profile.ui.screen.city.ui.CityItem
+import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import papakarlo.designsystem.generated.resources.Res
+import papakarlo.designsystem.generated.resources.action_select_city_continue
+import papakarlo.designsystem.generated.resources.description_select_city_location
 import papakarlo.designsystem.generated.resources.error_select_city_loading
+import papakarlo.designsystem.generated.resources.ic_select_city_location
+import papakarlo.designsystem.generated.resources.msg_select_city_single_city_available
 import papakarlo.designsystem.generated.resources.title_select_city
 
 @Composable
@@ -37,6 +58,7 @@ private fun SelectCityDataState.DataState.mapState(): SelectCityViewState =
                 SelectCityDataState.DataState.State.ERROR -> SelectCityViewState.State.Error
             },
         cityList = cityList,
+        contentMode = contentMode,
     )
 
 @Composable
@@ -86,7 +108,7 @@ private fun SelectCityScreen(
                 LoadingScreen()
             }
 
-            is SelectCityViewState.State.Success -> {
+            SelectCityViewState.State.Success -> {
                 SelectCitySuccessScreen(
                     viewState = viewState,
                     onAction = onAction,
@@ -108,6 +130,29 @@ private fun SelectCitySuccessScreen(
     viewState: SelectCityViewState,
     onAction: (SelectCityDataState.Action) -> Unit,
 ) {
+    when (viewState.contentMode) {
+        SelectCityDataState.DataState.ContentMode.CityList -> {
+            SelectCityListScreen(
+                viewState = viewState,
+                onAction = onAction,
+            )
+        }
+
+        SelectCityDataState.DataState.ContentMode.SingleCity -> {
+            val city = viewState.cityList.firstOrNull() ?: return
+            SelectCitySingleCityScreen(
+                city = city,
+                onAction = onAction,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SelectCityListScreen(
+    viewState: SelectCityViewState,
+    onAction: (SelectCityDataState.Action) -> Unit,
+) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = spacedBy(8.dp),
@@ -120,6 +165,74 @@ private fun SelectCitySuccessScreen(
                     onAction(SelectCityDataState.Action.OnCitySelected(city))
                 },
             )
+        }
+    }
+}
+
+@Composable
+private fun SelectCitySingleCityScreen(
+    city: City,
+    onAction: (SelectCityDataState.Action) -> Unit,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(color = FoodDeliveryTheme.colors.mainColors.background),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.weight(weight = 1f))
+
+        Box(
+            modifier =
+                Modifier
+                    .size(size = 120.dp)
+                    .clip(CircleShape)
+                    .background(color = FoodDeliveryTheme.colors.statusColors.warning),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                modifier = Modifier.size(size = 64.dp),
+                painter = painterResource(resource = Res.drawable.ic_select_city_location),
+                tint = FoodDeliveryTheme.colors.statusColors.onStatus,
+                contentDescription = stringResource(resource = Res.string.description_select_city_location),
+            )
+        }
+
+        Text(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 32.dp)
+                    .padding(horizontal = 16.dp),
+            text = stringResource(resource = Res.string.msg_select_city_single_city_available),
+            style = FoodDeliveryTheme.typography.bodyLarge,
+            color = FoodDeliveryTheme.colors.mainColors.onSurface,
+            textAlign = TextAlign.Center,
+        )
+
+        Text(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp)
+                    .padding(horizontal = 16.dp),
+            text = city.name,
+            style = FoodDeliveryTheme.typography.titleLarge.bold,
+            color = FoodDeliveryTheme.colors.mainColors.onSurface,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.weight(weight = 1f))
+
+        MainButton(
+            modifier =
+                Modifier
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = LocalBottomBarPadding.current + 16.dp),
+            textStringId = Res.string.action_select_city_continue,
+        ) {
+            onAction(SelectCityDataState.Action.OnContinueClicked)
         }
     }
 }
@@ -156,8 +269,31 @@ private fun SelectCitySuccessScreenPreview() {
                                 timeZone = "",
                             ),
                             City(
-                                uuid = "123",
+                                uuid = "456",
                                 name = "Москва",
+                                timeZone = "",
+                            ),
+                        ),
+                ),
+            onAction = { },
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SelectCitySingleCityScreenPreview() {
+    FoodDeliveryTheme {
+        SelectCityScreen(
+            viewState =
+                SelectCityViewState(
+                    state = SelectCityViewState.State.Success,
+                    contentMode = SelectCityDataState.DataState.ContentMode.SingleCity,
+                    cityList =
+                        listOf(
+                            City(
+                                uuid = "123",
+                                name = "Кимры",
                                 timeZone = "",
                             ),
                         ),
@@ -183,7 +319,7 @@ private fun SelectCityLoadingScreenPreview() {
                                 timeZone = "",
                             ),
                             City(
-                                uuid = "123",
+                                uuid = "456",
                                 name = "Москва",
                                 timeZone = "",
                             ),

--- a/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/ui/screen/city/screen/selectcity/SelectCityRoute.kt
+++ b/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/ui/screen/city/screen/selectcity/SelectCityRoute.kt
@@ -139,11 +139,18 @@ private fun SelectCitySuccessScreen(
         }
 
         SelectCityDataState.DataState.ContentMode.SingleCity -> {
-            val city = viewState.cityList.firstOrNull() ?: return
-            SelectCitySingleCityScreen(
-                city = city,
-                onAction = onAction,
-            )
+            val city = viewState.cityList.firstOrNull()
+            if (city == null) {
+                ErrorScreen(
+                    mainTextId = Res.string.error_select_city_loading,
+                    onClick = { onAction(SelectCityDataState.Action.OnRefreshClicked) },
+                )
+            } else {
+                SelectCitySingleCityScreen(
+                    city = city,
+                    onAction = onAction,
+                )
+            }
         }
     }
 }

--- a/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/ui/screen/city/screen/selectcity/SelectCityViewState.kt
+++ b/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/ui/screen/city/screen/selectcity/SelectCityViewState.kt
@@ -3,11 +3,13 @@ package com.bunbeauty.profile.ui.screen.city.screen.selectcity
 import androidx.compose.runtime.Immutable
 import com.bunbeauty.core.base.BaseViewState
 import com.bunbeauty.core.model.city.City
+import com.bunbeauty.profile.presentation.selectcity.SelectCityDataState
 
 @Immutable
 data class SelectCityViewState(
     val state: State,
     val cityList: List<City> = emptyList(),
+    val contentMode: SelectCityDataState.DataState.ContentMode = SelectCityDataState.DataState.ContentMode.CityList,
 ) : BaseViewState {
     @Immutable
     sealed interface State {

--- a/feature/splash/src/commonMain/kotlin/com/bunbeauty/splash/di/SplashFeatureModule.kt
+++ b/feature/splash/src/commonMain/kotlin/com/bunbeauty/splash/di/SplashFeatureModule.kt
@@ -10,8 +10,6 @@ fun splashFeatureModule() =
             SplashViewModel(
                 checkUpdateUseCase = get(),
                 cityInteractor = get(),
-                getIsOneCityUseCase = get(),
-                saveOneCityUseCase = get(),
             )
         }
     }

--- a/feature/splash/src/commonMain/kotlin/com/bunbeauty/splash/presentation/SplashViewModel.kt
+++ b/feature/splash/src/commonMain/kotlin/com/bunbeauty/splash/presentation/SplashViewModel.kt
@@ -32,7 +32,9 @@ class SplashViewModel(
                 }
             },
             onError = {
-                // add error state
+                addEvent {
+                    Splash.Effect.NavigateToUpdateEffect
+                }
             },
         )
     }

--- a/feature/splash/src/commonMain/kotlin/com/bunbeauty/splash/presentation/SplashViewModel.kt
+++ b/feature/splash/src/commonMain/kotlin/com/bunbeauty/splash/presentation/SplashViewModel.kt
@@ -2,16 +2,12 @@ package com.bunbeauty.splash.presentation
 
 import com.bunbeauty.core.base.SharedStateViewModel
 import com.bunbeauty.core.domain.city.ICityInteractor
-import com.bunbeauty.core.domain.splash.CheckOneCityUseCase
 import com.bunbeauty.core.domain.splash.CheckUpdateUseCase
-import com.bunbeauty.core.domain.splash.SaveOneCityUseCase
 import com.bunbeauty.core.extension.launchSafe
 
 class SplashViewModel(
     private val checkUpdateUseCase: CheckUpdateUseCase,
     private val cityInteractor: ICityInteractor,
-    private val getIsOneCityUseCase: CheckOneCityUseCase,
-    private val saveOneCityUseCase: SaveOneCityUseCase,
 ) : SharedStateViewModel<Splash.DataState, Splash.Action, Splash.Effect>(
         initDataState = Splash.DataState,
     ) {
@@ -43,17 +39,6 @@ class SplashViewModel(
 
     private suspend fun checkIsCitySelected() {
         if (cityInteractor.checkIsCitySelected()) {
-            addEvent {
-                Splash.Effect.NavigateToMenuEffect
-            }
-        } else {
-            checkOneCity()
-        }
-    }
-
-    private suspend fun checkOneCity() {
-        if (getIsOneCityUseCase()) {
-            saveOneCityUseCase()
             addEvent {
                 Splash.Effect.NavigateToMenuEffect
             }

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/ViewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/ViewModelModule.kt
@@ -31,6 +31,7 @@ fun viewModelModule() =
         viewModel {
             SelectCityViewModel(
                 cityInteractor = get(),
+                checkOneCityUseCase = get(),
             )
         }
     }

--- a/shared/src/commonTest/kotlin/com/bunbeauty/domain/feature/splash/CheckOneCityUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/bunbeauty/domain/feature/splash/CheckOneCityUseCaseTest.kt
@@ -60,4 +60,31 @@ class CheckOneCityUseCaseTest {
             // Then
             assertFalse(result)
         }
+
+    @Test
+    fun `invoke with city list returns true when list has exactly one city`() {
+        val result =
+            useCase.invoke(
+                cityList =
+                    listOf(
+                        getCity(),
+                    ),
+            )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `invoke with city list returns false when list has more than one city`() {
+        val result =
+            useCase.invoke(
+                cityList =
+                    listOf(
+                        getCity(name = "City1"),
+                        getCity(name = "City2"),
+                    ),
+            )
+
+        assertFalse(result)
+    }
 }


### PR DESCRIPTION
## Summary
- Убран автоматический переход в меню при одном доступном городе на splash.
- На SelectCity добавлен экран подтверждения одного города по Figma (иконка, текст, имя города, «Продолжить»).
- При нескольких городах сохранён список с выбором.

## Test plan
- [x] Splash без выбранного города и 1 город в API → открывается SelectCity (single), не меню
- [x] «Продолжить» сохраняет город и ведёт в меню
- [x] 2+ города → список, выбор города → меню
- [ ] Ошибка загрузки → ErrorScreen + retry
- [ ] Previews single-city / list