### PR TITLE
Fix iOS Firebase Analytics compile errors

### DIFF
--- a/analytic/src/iosMain/kotlin/com/bunbeauty/analytic/AnalyticService.kt
+++ b/analytic/src/iosMain/kotlin/com/bunbeauty/analytic/AnalyticService.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
 package com.bunbeauty.analytic
 
 import cocoapods.FirebaseAnalytics.FIRAnalytics
@@ -7,7 +9,9 @@ import com.bunbeauty.analytic.event.toMap
 import com.bunbeauty.core.Logger
 import com.bunbeauty.core.Logger.ANALYTIC_TAG
 import com.bunbeauty.core.targetName
+import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSMutableDictionary
+import platform.Foundation.NSString
 
 actual class AnalyticService {
     actual fun sendEvent(event: FoodDeliveryEvent) {
@@ -25,7 +29,7 @@ private fun List<EventParameter>.toFirebaseParameters(): Map<Any?, *>? {
 
     val dictionary = NSMutableDictionary(capacity = size.toULong())
     forEach { parameter ->
-        dictionary.setObject(parameter.value, forKey = parameter.key)
+        dictionary.setObject(parameter.value as NSString, forKey = parameter.key as NSString)
     }
     return dictionary as Map<Any?, *>
 }

--- a/analytic/src/iosMain/kotlin/com/bunbeauty/analytic/di/AnalyticModule.kt
+++ b/analytic/src/iosMain/kotlin/com/bunbeauty/analytic/di/AnalyticModule.kt
@@ -1,8 +1,11 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
 package com.bunbeauty.analytic.di
 
 import cocoapods.FirebaseAnalytics.FIRAnalytics
 import com.bunbeauty.analytic.AnalyticService
 import com.bunbeauty.core.isDebugQualifier
+import kotlinx.cinterop.ExperimentalForeignApi
 import org.koin.dsl.module
 
 actual fun analyticModule() =


### PR DESCRIPTION
## Summary
Hotfix для :analytic:compileKotlinIosArm64 в iOS publish workflow.

- @file:OptIn(ExperimentalForeignApi::class) в AnalyticService.kt и AnalyticModule.kt
- NSString casts для NSMutableDictionary.setObject

## Test plan
- [ ] ./gradlew :analytic:compileKotlinIosArm64 проходит локально/в CI
- [ ] Publish workflow ios (upload) собирает все IPA