### PR TITLE
Fix App Store version creation for fastlane 2.222

### DIFF
--- a/iosApp/fastlane/Fastfile
+++ b/iosApp/fastlane/Fastfile
@@ -127,10 +127,12 @@ platform :ios do
     end
 
     UI.message("Создаём App Store version #{version_string} для #{app_identifier}")
-    Spaceship::ConnectAPI::AppStoreVersion.create(
+    Spaceship::ConnectAPI.post_app_store_version(
       app_id: app.id,
-      platform: platform,
-      version_string: version_string
+      attributes: {
+        versionString: version_string,
+        platform: platform
+      }
     )
   end
 


### PR DESCRIPTION
## Summary

Fixes failed iOS submit workflow (`publish-workflow-ios-submit.yml`) where all 11 matrix jobs failed at step "Submit app for App Store review".

**Root cause:** `ensure_editable_app_store_version` called `Spaceship::ConnectAPI::AppStoreVersion.create(...)`, which does not exist in pinned fastlane 2.222.0.

**Fix:** Use `Spaceship::ConnectAPI.post_app_store_version` with correct attributes (`versionString`, `platform`).

## Test plan

- [ ] Merge to develop
- [ ] Re-run Publish workflow ios (submit) or trigger via workflow_run
- [ ] Verify submit jobs pass `ensure_editable_app_store_version` step