### PR TITLE
Fix App Store version creation for fastlane 2.222 (hotfix)

### DIFF
--- a/iosApp/fastlane/Fastfile
+++ b/iosApp/fastlane/Fastfile
@@ -127,10 +127,12 @@ platform :ios do
     end
 
     UI.message("Создаём App Store version #{version_string} для #{app_identifier}")
-    Spaceship::ConnectAPI::AppStoreVersion.create(
+    Spaceship::ConnectAPI.post_app_store_version(
       app_id: app.id,
-      platform: platform,
-      version_string: version_string
+      attributes: {
+        versionString: version_string,
+        platform: platform
+      }
     )
   end
 


### PR DESCRIPTION
Cherry-pick fix for iOS submit workflow on master. Uses Spaceship::ConnectAPI.post_app_store_version instead of non-existent AppStoreVersion.create.