### PR TITLE
Add favorites on ProductDetails and menu section

### DIFF
--- a/analytic/src/commonMain/kotlin/com/bunbeauty/analytic/event/favorite/AddFavoriteClickEvent.kt
+++ b/analytic/src/commonMain/kotlin/com/bunbeauty/analytic/event/favorite/AddFavoriteClickEvent.kt
@@ -1,0 +1,12 @@
+package com.bunbeauty.analytic.event.favorite
+
+import com.bunbeauty.analytic.event.FoodDeliveryEvent
+import com.bunbeauty.analytic.parameter.MenuProductUuidEventParameter
+
+class AddFavoriteClickEvent(
+    menuProductUuidEventParameter: MenuProductUuidEventParameter,
+) : FoodDeliveryEvent(
+        category = "favorite",
+        action = "add",
+        params = listOf(menuProductUuidEventParameter),
+    )

--- a/analytic/src/commonMain/kotlin/com/bunbeauty/analytic/event/favorite/RemoveFavoriteClickEvent.kt
+++ b/analytic/src/commonMain/kotlin/com/bunbeauty/analytic/event/favorite/RemoveFavoriteClickEvent.kt
@@ -1,0 +1,12 @@
+package com.bunbeauty.analytic.event.favorite
+
+import com.bunbeauty.analytic.event.FoodDeliveryEvent
+import com.bunbeauty.analytic.parameter.MenuProductUuidEventParameter
+
+class RemoveFavoriteClickEvent(
+    menuProductUuidEventParameter: MenuProductUuidEventParameter,
+) : FoodDeliveryEvent(
+        category = "favorite",
+        action = "remove",
+        params = listOf(menuProductUuidEventParameter),
+    )

--- a/analytic/src/commonTest/kotlin/com/bunbeauty/analytic/event/FoodDeliveryEventNameTest.kt
+++ b/analytic/src/commonTest/kotlin/com/bunbeauty/analytic/event/FoodDeliveryEventNameTest.kt
@@ -9,6 +9,8 @@ import com.bunbeauty.analytic.event.cart.DecreaseCartProductClickEvent
 import com.bunbeauty.analytic.event.cart.IncreaseCartProductClickEvent
 import com.bunbeauty.analytic.event.cart.RemoveCartProductClickEvent
 import com.bunbeauty.analytic.event.city.CitySelectEvent
+import com.bunbeauty.analytic.event.favorite.AddFavoriteClickEvent
+import com.bunbeauty.analytic.event.favorite.RemoveFavoriteClickEvent
 import com.bunbeauty.analytic.event.menu.AddMenuProductClickEvent
 import com.bunbeauty.analytic.event.menu.AddMenuProductDetailsClickEvent
 import com.bunbeauty.analytic.event.menu.LoadedMenuEvent
@@ -51,6 +53,12 @@ class FoodDeliveryEventNameTest {
                     menuProductUuidEventParameter = MenuProductUuidEventParameter(value = "uuid"),
                 ),
                 AddRecommendationProductDetailsClickEvent(
+                    menuProductUuidEventParameter = MenuProductUuidEventParameter(value = "uuid"),
+                ),
+                AddFavoriteClickEvent(
+                    menuProductUuidEventParameter = MenuProductUuidEventParameter(value = "uuid"),
+                ),
+                RemoveFavoriteClickEvent(
                     menuProductUuidEventParameter = MenuProductUuidEventParameter(value = "uuid"),
                 ),
                 AuthConfirmErrorEvent(error = "InvalidCode"),

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/Constants.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/Constants.kt
@@ -27,6 +27,10 @@ object Constants {
 
     const val CART_PRODUCT_LIMIT = 99
 
+    // MENU
+
+    const val FAVORITES_CATEGORY_UUID = "favorites"
+
     // TIME
 
     const val MIN_DEFERRED_HOURS_ADDITION = 1

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/GetFavoriteMenuProductsUseCase.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/GetFavoriteMenuProductsUseCase.kt
@@ -1,0 +1,35 @@
+package com.bunbeauty.core.domain.favorite
+
+import com.bunbeauty.core.domain.menu_product.GetMenuProductListUseCase
+import com.bunbeauty.core.domain.repo.FavoriteRepo
+import com.bunbeauty.core.domain.repo.UserRepo
+import com.bunbeauty.core.model.product.MenuProduct
+
+class GetFavoriteMenuProductsUseCase(
+    private val favoriteRepo: FavoriteRepo,
+    private val getMenuProductListUseCase: GetMenuProductListUseCase,
+    private val userRepo: UserRepo,
+) {
+    suspend operator fun invoke(): List<MenuProduct> {
+        if (userRepo.getToken() == null) {
+            return emptyList()
+        }
+
+        val favoriteList = favoriteRepo.getFavoriteList()
+        if (favoriteList.isEmpty()) {
+            return emptyList()
+        }
+
+        val menuProductByUuid =
+            getMenuProductListUseCase().associateBy { menuProduct ->
+                menuProduct.uuid
+            }
+
+        return favoriteList
+            .sortedByDescending { favorite ->
+                favorite.createdAtMillis
+            }.mapNotNull { favorite ->
+                menuProductByUuid[favorite.menuProductUuid]
+            }
+    }
+}

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/IsProductFavoriteUseCase.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/IsProductFavoriteUseCase.kt
@@ -1,0 +1,17 @@
+package com.bunbeauty.core.domain.favorite
+
+import com.bunbeauty.core.domain.repo.FavoriteRepo
+import com.bunbeauty.core.domain.repo.UserRepo
+
+class IsProductFavoriteUseCase(
+    private val favoriteRepo: FavoriteRepo,
+    private val userRepo: UserRepo,
+) {
+    suspend operator fun invoke(menuProductUuid: String): Boolean {
+        if (userRepo.getToken() == null) {
+            return false
+        }
+
+        return favoriteRepo.isFavorite(menuProductUuid = menuProductUuid)
+    }
+}

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/LoadFavoritesUseCase.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/LoadFavoritesUseCase.kt
@@ -1,0 +1,15 @@
+package com.bunbeauty.core.domain.favorite
+
+import com.bunbeauty.core.domain.repo.FavoriteRepo
+import com.bunbeauty.core.domain.repo.UserRepo
+
+class LoadFavoritesUseCase(
+    private val favoriteRepo: FavoriteRepo,
+    private val userRepo: UserRepo,
+) {
+    suspend operator fun invoke() {
+        if (userRepo.getToken() != null) {
+            favoriteRepo.getFavoriteList()
+        }
+    }
+}

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/ToggleFavoriteUseCase.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/ToggleFavoriteUseCase.kt
@@ -1,0 +1,25 @@
+package com.bunbeauty.core.domain.favorite
+
+import com.bunbeauty.core.domain.exeptions.NoTokenException
+import com.bunbeauty.core.domain.repo.FavoriteRepo
+import com.bunbeauty.core.domain.repo.UserRepo
+
+class ToggleFavoriteUseCase(
+    private val favoriteRepo: FavoriteRepo,
+    private val userRepo: UserRepo,
+) {
+    suspend operator fun invoke(menuProductUuid: String): Boolean {
+        if (userRepo.getToken() == null) {
+            throw NoTokenException()
+        }
+
+        val isFavorite = favoriteRepo.isFavorite(menuProductUuid = menuProductUuid)
+        if (isFavorite) {
+            favoriteRepo.removeFavorite(menuProductUuid = menuProductUuid)
+            return false
+        }
+
+        favoriteRepo.addFavorite(menuProductUuid = menuProductUuid)
+        return true
+    }
+}

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/di/FavoriteModule.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/di/FavoriteModule.kt
@@ -1,5 +1,6 @@
 package com.bunbeauty.core.domain.favorite.di
 
+import com.bunbeauty.core.domain.favorite.GetFavoriteMenuProductsUseCase
 import com.bunbeauty.core.domain.favorite.IsProductFavoriteUseCase
 import com.bunbeauty.core.domain.favorite.LoadFavoritesUseCase
 import com.bunbeauty.core.domain.favorite.ToggleFavoriteUseCase
@@ -22,6 +23,13 @@ fun favoriteModule() =
         factory {
             ToggleFavoriteUseCase(
                 favoriteRepo = get(),
+                userRepo = get(),
+            )
+        }
+        factory {
+            GetFavoriteMenuProductsUseCase(
+                favoriteRepo = get(),
+                getMenuProductListUseCase = get(),
                 userRepo = get(),
             )
         }

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/di/FavoriteModule.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/favorite/di/FavoriteModule.kt
@@ -1,0 +1,28 @@
+package com.bunbeauty.core.domain.favorite.di
+
+import com.bunbeauty.core.domain.favorite.IsProductFavoriteUseCase
+import com.bunbeauty.core.domain.favorite.LoadFavoritesUseCase
+import com.bunbeauty.core.domain.favorite.ToggleFavoriteUseCase
+import org.koin.dsl.module
+
+fun favoriteModule() =
+    module {
+        factory {
+            LoadFavoritesUseCase(
+                favoriteRepo = get(),
+                userRepo = get(),
+            )
+        }
+        factory {
+            IsProductFavoriteUseCase(
+                favoriteRepo = get(),
+                userRepo = get(),
+            )
+        }
+        factory {
+            ToggleFavoriteUseCase(
+                favoriteRepo = get(),
+                userRepo = get(),
+            )
+        }
+    }

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/repo/FavoriteRepo.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/repo/FavoriteRepo.kt
@@ -1,0 +1,15 @@
+package com.bunbeauty.core.domain.repo
+
+import com.bunbeauty.core.model.Favorite
+
+interface FavoriteRepo {
+    suspend fun getFavoriteList(): List<Favorite>
+
+    suspend fun isFavorite(menuProductUuid: String): Boolean
+
+    suspend fun addFavorite(menuProductUuid: String)
+
+    suspend fun removeFavorite(menuProductUuid: String)
+
+    suspend fun clearCache()
+}

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/user/UserInteractor.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/user/UserInteractor.kt
@@ -2,6 +2,7 @@ package com.bunbeauty.core.domain.user
 
 import com.bunbeauty.core.domain.repo.CafeRepo
 import com.bunbeauty.core.domain.repo.CreateOrderSettingsRepo
+import com.bunbeauty.core.domain.repo.FavoriteRepo
 import com.bunbeauty.core.domain.repo.OrderRepo
 import com.bunbeauty.core.domain.repo.UserAddressRepo
 import com.bunbeauty.core.domain.repo.UserRepo
@@ -13,12 +14,14 @@ class UserInteractor(
     private val cafeRepo: CafeRepo,
     private val userAddressRepo: UserAddressRepo,
     private val createOrderSettingsRepo: CreateOrderSettingsRepo,
+    private val favoriteRepo: FavoriteRepo,
 ) : IUserInteractor {
     override suspend fun clearUserCache() {
         userRepo.clearUserCache()
         orderRepo.clearCache()
         cafeRepo.clearCache()
         userAddressRepo.clearCache()
+        favoriteRepo.clearCache()
         createOrderSettingsRepo.clearWithoutUtensils()
     }
 

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/model/Favorite.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/model/Favorite.kt
@@ -1,0 +1,6 @@
+package com.bunbeauty.core.model
+
+data class Favorite(
+    val menuProductUuid: String,
+    val createdAtMillis: Long,
+)

--- a/designsystem/src/commonMain/composeResources/drawable/ic_favorite_24.xml
+++ b/designsystem/src/commonMain/composeResources/drawable/ic_favorite_24.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M16.5,3C14.76,3 13.09,3.81 12,5.09C10.91,3.81 9.24,3 7.5,3C4.42,3 2,5.42 2,8.5C2,12.28 5.4,15.36 10.55,20.04L12,21.35L13.45,20.04C18.6,15.36 22,12.28 22,8.5C22,5.42 19.58,3 16.5,3Z"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#989898"/>
+</vector>

--- a/designsystem/src/commonMain/composeResources/drawable/ic_favorite_filled_24.xml
+++ b/designsystem/src/commonMain/composeResources/drawable/ic_favorite_filled_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M16.5,3C14.76,3 13.09,3.81 12,5.09C10.91,3.81 9.24,3 7.5,3C4.42,3 2,5.42 2,8.5C2,12.28 5.4,15.36 10.55,20.04L12,21.35L13.45,20.04C18.6,15.36 22,12.28 22,8.5C22,5.42 19.58,3 16.5,3Z"
+      android:fillColor="#FF000000"/>
+</vector>

--- a/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -59,6 +59,7 @@
 
     <!-- MENU -->
     <string name="title_menu">Меню</string>
+    <string name="title_favorites">Избранные</string>
     <string name="error_menu_loading">Не удалось загрузить меню</string>
     <string name="title_menu_discount">Скидка %1$s%</string>
     <string name="msg_menu_discount">Успей сделать первый заказ со скидкой %1$s%</string>

--- a/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -59,7 +59,7 @@
 
     <!-- MENU -->
     <string name="title_menu">Меню</string>
-    <string name="title_favorites">Избранные</string>
+    <string name="title_favorites">Избранные ❤️</string>
     <string name="error_menu_loading">Не удалось загрузить меню</string>
     <string name="title_menu_discount">Скидка %1$s%</string>
     <string name="msg_menu_discount">Успей сделать первый заказ со скидкой %1$s%</string>

--- a/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="description_ic_next">Переход</string>
     <string name="description_ic_checked">Выбрано</string>
     <string name="description_product">Фото блюда</string>
+    <string name="description_favorite">Избранное</string>
     <string name="description_product_addition">Фото добавки</string>
     <string name="description_ic_discount">Скидка</string>
     <string name="description_ic_warning">Предупреждение</string>

--- a/designsystem/src/commonMain/kotlin/com/bunbeauty/designsystem/ui/element/FoodDeliveryToolbarActions.kt
+++ b/designsystem/src/commonMain/kotlin/com/bunbeauty/designsystem/ui/element/FoodDeliveryToolbarActions.kt
@@ -1,12 +1,16 @@
 package com.bunbeauty.designsystem.ui.element
 
+import androidx.compose.ui.graphics.Color
 import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.StringResource
 
 sealed interface FoodDeliveryToolbarActions
 
 class FoodDeliveryAction(
     val iconId: DrawableResource,
     val onClick: () -> Unit,
+    val tint: Color? = null,
+    val contentDescriptionId: StringResource? = null,
 ) : FoodDeliveryToolbarActions
 
 class FoodDeliveryCartAction(

--- a/designsystem/src/commonMain/kotlin/com/bunbeauty/designsystem/ui/topbar/FoodDeliveryTopAppBar.kt
+++ b/designsystem/src/commonMain/kotlin/com/bunbeauty/designsystem/ui/topbar/FoodDeliveryTopAppBar.kt
@@ -35,6 +35,7 @@ import com.bunbeauty.designsystem.ui.icon24
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 import papakarlo.designsystem.generated.resources.Res
 import papakarlo.designsystem.generated.resources.ic_arrow_back
 import papakarlo.designsystem.generated.resources.ic_cart_24
@@ -143,8 +144,11 @@ private fun Action(action: FoodDeliveryAction) {
         Icon(
             modifier = Modifier.icon20(),
             painter = painterResource(resource = action.iconId),
-            tint = FoodDeliveryTheme.colors.mainColors.onSurfaceVariant,
-            contentDescription = null,
+            tint = action.tint ?: FoodDeliveryTheme.colors.mainColors.onSurfaceVariant,
+            contentDescription =
+                action.contentDescriptionId?.let { contentDescriptionId ->
+                    stringResource(resource = contentDescriptionId)
+                },
         )
     }
 }

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/di/MenuFeatureModule.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/di/MenuFeatureModule.kt
@@ -17,6 +17,7 @@ fun menuFeatureModule() =
                 stopObserveOrdersUseCase = get(),
                 getLastOrderUseCase = get(),
                 observeTokenUseCase = get(),
+                getFavoriteMenuProductsUseCase = get(),
             )
         }
     }

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuGridIndex.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuGridIndex.kt
@@ -1,0 +1,11 @@
+package com.bunbeauty.menu.presentation
+
+internal const val MENU_GRID_INDEX_LAST_ORDER = 2
+internal const val MENU_GRID_INDEX_FAVORITES = 3
+
+internal fun menuContentStartGridIndex(hasFavoritesSection: Boolean): Int =
+    if (hasFavoritesSection) {
+        MENU_GRID_INDEX_FAVORITES + 1
+    } else {
+        MENU_GRID_INDEX_FAVORITES
+    }

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuState.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuState.kt
@@ -13,6 +13,7 @@ interface MenuState {
         val categoryItemList: List<CategoryItem>,
         val cartCostAndCount: CartCostAndCount?,
         val menuItemList: List<MenuItem>,
+        val favoriteProductList: List<MenuItem.Product> = emptyList(),
         val state: State,
         val userScrollEnabled: Boolean,
         val lastOrder: LightOrder?,
@@ -58,6 +59,8 @@ interface MenuState {
         data object StartLastOrderObservation : Action
 
         data object StopLastOrderObservation : Action
+
+        data object RefreshFavorites : Action
     }
 
     sealed interface Event : BaseEvent {

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuViewModel.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuViewModel.kt
@@ -6,10 +6,12 @@ import com.bunbeauty.analytic.event.menu.LoadedMenuEvent
 import com.bunbeauty.analytic.parameter.MenuProductUuidEventParameter
 import com.bunbeauty.analytic.parameter.TimeParameter
 import com.bunbeauty.core.Logger
+import com.bunbeauty.core.Constants.FAVORITES_CATEGORY_UUID
 import com.bunbeauty.core.base.SharedStateViewModel
 import com.bunbeauty.core.domain.ObserveCartUseCase
 import com.bunbeauty.core.domain.auth.ObserveTokenUseCase
 import com.bunbeauty.core.domain.discount.GetDiscountUseCase
+import com.bunbeauty.core.domain.favorite.GetFavoriteMenuProductsUseCase
 import com.bunbeauty.core.domain.menu_product.AddMenuProductUseCase
 import com.bunbeauty.core.domain.menu_product.IMenuProductInteractor
 import com.bunbeauty.core.domain.order.GetLastOrderUseCase
@@ -19,6 +21,7 @@ import com.bunbeauty.core.extension.launchSafe
 import com.bunbeauty.core.model.CategoryItem
 import com.bunbeauty.core.model.MenuItem
 import com.bunbeauty.core.model.mapper.toMenuItemList
+import com.bunbeauty.core.model.mapper.toMenuProductItem
 import com.bunbeauty.core.model.menu.MenuSection
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -30,9 +33,6 @@ import kotlin.time.measureTime
 
 private const val MAIN_MENU_VIEW_MODEL_TAG = "MenuViewModel"
 
-// Grid: 0=TopBar, 1=CategoryRow, 2=LastOrder, 3+=menuItemList
-internal const val MENU_FIRST_CONTENT_GRID_INDEX = 3
-
 class MenuViewModel(
     private val menuProductInteractor: IMenuProductInteractor,
     private val observeCartUseCase: ObserveCartUseCase,
@@ -43,12 +43,14 @@ class MenuViewModel(
     private val stopObserveOrdersUseCase: StopObserveOrdersUseCase,
     private val getLastOrderUseCase: GetLastOrderUseCase,
     private val observeTokenUseCase: ObserveTokenUseCase,
+    private val getFavoriteMenuProductsUseCase: GetFavoriteMenuProductsUseCase,
 ) : SharedStateViewModel<MenuState.DataState, MenuState.Action, MenuState.Event>(
         initDataState =
             MenuState.DataState(
                 categoryItemList = emptyList(),
                 cartCostAndCount = null,
                 menuItemList = emptyList(),
+                favoriteProductList = emptyList(),
                 state = MenuState.DataState.State.LOADING,
                 userScrollEnabled = true,
                 lastOrder = null,
@@ -89,6 +91,7 @@ class MenuViewModel(
             MenuState.Action.OnCartClicked -> onCartClicked()
             MenuState.Action.StartLastOrderObservation -> startLastOrderObservation()
             MenuState.Action.StopLastOrderObservation -> stopLastOrderObservation()
+            MenuState.Action.RefreshFavorites -> refreshFavoriteProducts()
         }
     }
 
@@ -127,6 +130,7 @@ class MenuViewModel(
                     .distinctUntilChanged()
                     .collectLatest {
                         refreshDiscount()
+                        refreshFavoriteProducts()
                     }
             },
             onError = { throwable ->
@@ -170,9 +174,15 @@ class MenuViewModel(
                 val time =
                     measureTime {
                         val menuSectionList = menuProductInteractor.getMenuSectionList()
+                        val favoriteProductList = loadFavoriteProductList()
 
                         if (selectedCategoryUuid == null) {
-                            selectedCategoryUuid = menuSectionList.firstOrNull()?.category?.uuid
+                            selectedCategoryUuid =
+                                if (favoriteProductList.isNotEmpty()) {
+                                    FAVORITES_CATEGORY_UUID
+                                } else {
+                                    menuSectionList.firstOrNull()?.category?.uuid
+                                }
                         }
 
                         val discountItem =
@@ -186,10 +196,11 @@ class MenuViewModel(
                                 }
                         setState {
                             copy(
-                                categoryItemList =
-                                    menuSectionList.map { menuSection ->
-                                        toCategoryItemModel(menuSection)
-                                    },
+                                categoryItemList = buildCategoryItemList(
+                                    menuSectionList = menuSectionList,
+                                    favoriteProductList = favoriteProductList,
+                                ),
+                                favoriteProductList = favoriteProductList,
                                 menuItemList = menuItemList,
                                 state = MenuState.DataState.State.SUCCESS,
                             )
@@ -217,7 +228,16 @@ class MenuViewModel(
         }
 
         currentMenuPosition = menuPosition
-        val menuListPosition = (menuPosition - MENU_FIRST_CONTENT_GRID_INDEX).coerceAtLeast(0)
+        val hasFavoritesSection = mutableDataState.value.favoriteProductList.isNotEmpty()
+
+        if (hasFavoritesSection && menuPosition == MENU_GRID_INDEX_FAVORITES) {
+            setCategory(FAVORITES_CATEGORY_UUID)
+            return
+        }
+
+        val menuListPosition =
+            (menuPosition - menuContentStartGridIndex(hasFavoritesSection = hasFavoritesSection))
+                .coerceAtLeast(0)
 
         sharedScope.launchSafe(
             block = {
@@ -273,10 +293,12 @@ class MenuViewModel(
     }
 
     private fun findMenuProduct(uuid: String): MenuItem.Product? =
-        mutableDataState.value.menuItemList
+        mutableDataState.value.favoriteProductList.find { menuProduct ->
+            menuProduct.uuid == uuid
+        } ?: mutableDataState.value.menuItemList
             .filterIsInstance<MenuItem.Product>()
-            .find { menuItem ->
-                menuItem.uuid == uuid
+            .find { menuProduct ->
+                menuProduct.uuid == uuid
             }
 
     private fun onAddProductClicked(menuProductUuid: String) {
@@ -351,6 +373,62 @@ class MenuViewModel(
             name = menuSection.category.name,
             isSelected = isCategorySelected(menuSection.category.uuid),
         )
+
+    private fun toFavoritesCategoryItem(): CategoryItem =
+        CategoryItem(
+            key = "CategoryItemModel $FAVORITES_CATEGORY_UUID",
+            uuid = FAVORITES_CATEGORY_UUID,
+            name = "",
+            isSelected = isCategorySelected(FAVORITES_CATEGORY_UUID),
+        )
+
+    private fun buildCategoryItemList(
+        menuSectionList: List<MenuSection>,
+        favoriteProductList: List<MenuItem.Product>,
+    ): List<CategoryItem> {
+        val menuCategoryList =
+            menuSectionList.map { menuSection ->
+                toCategoryItemModel(menuSection)
+            }
+
+        return if (favoriteProductList.isNotEmpty()) {
+            listOf(toFavoritesCategoryItem()) + menuCategoryList
+        } else {
+            menuCategoryList
+        }
+    }
+
+    private suspend fun loadFavoriteProductList(): List<MenuItem.Product> =
+        getFavoriteMenuProductsUseCase().map { menuProduct ->
+            menuProduct.toMenuProductItem()
+        }
+
+    private fun refreshFavoriteProducts() {
+        sharedScope.launchSafe(
+            block = {
+                val favoriteProductList = loadFavoriteProductList()
+                val menuSectionList = menuProductInteractor.getMenuSectionList()
+
+                if (selectedCategoryUuid == FAVORITES_CATEGORY_UUID && favoriteProductList.isEmpty()) {
+                    selectedCategoryUuid = menuSectionList.firstOrNull()?.category?.uuid
+                }
+
+                setState {
+                    copy(
+                        favoriteProductList = favoriteProductList,
+                        categoryItemList =
+                            buildCategoryItemList(
+                                menuSectionList = menuSectionList,
+                                favoriteProductList = favoriteProductList,
+                            ),
+                    )
+                }
+            },
+            onError = { throwable ->
+                Logger.logE(MAIN_MENU_VIEW_MODEL_TAG, throwable.stackTraceToString())
+            },
+        )
+    }
 
     private fun isCategorySelected(categoryUuid: String): Boolean =
         selectedCategoryUuid?.let {

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/CategoryItem.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/CategoryItem.kt
@@ -10,12 +10,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.bunbeauty.core.Constants.FAVORITES_CATEGORY_UUID
 import com.bunbeauty.core.model.CategoryItem
 import com.bunbeauty.designsystem.theme.FoodDeliveryTheme
 import com.bunbeauty.designsystem.theme.medium
 import com.bunbeauty.designsystem.ui.element.card.FoodDeliveryCard
 import com.bunbeauty.designsystem.ui.element.card.FoodDeliveryCardDefaults
+import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import papakarlo.designsystem.generated.resources.Res
+import papakarlo.designsystem.generated.resources.title_favorites
 
 @Composable
 fun CategoryItem(
@@ -40,6 +44,13 @@ fun CategoryItem(
             )
         }
 
+    val displayName =
+        if (categoryItem.uuid == FAVORITES_CATEGORY_UUID) {
+            stringResource(resource = Res.string.title_favorites)
+        } else {
+            categoryItem.name
+        }
+
     FoodDeliveryCard(
         modifier = modifier,
         elevated = false,
@@ -59,7 +70,7 @@ fun CategoryItem(
                         horizontal = 12.dp,
                         vertical = 6.dp,
                     ),
-            text = categoryItem.name,
+            text = displayName,
             style = FoodDeliveryTheme.typography.labelLarge.medium,
             textAlign = TextAlign.Center,
         )

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuCategoryRow.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuCategoryRow.kt
@@ -29,6 +29,7 @@ private const val MENU_CATEGORY_ROW_INDEX = 1
 internal fun MenuCategoryRow(
     categoryItemList: ImmutableList<CategoryItem>,
     menuItemList: ImmutableList<MenuItemUi>,
+    hasFavoritesSection: Boolean,
     menuLazyGridState: LazyGridState,
     modifier: Modifier = Modifier,
     onAction: (MenuState.Action) -> Unit,
@@ -76,6 +77,7 @@ internal fun MenuCategoryRow(
                                 getMenuListPosition(
                                     categoryItem = categoryItemModel,
                                     menuItemList = menuItemList,
+                                    hasFavoritesSection = hasFavoritesSection,
                                 )
                             menuLazyGridState.alignCategoryHeaderUnderCategoryRow(
                                 headerGridIndex = index,

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuColumn.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuColumn.kt
@@ -170,6 +170,7 @@ internal fun MenuColumn(
                             .ignoreHorizontalParentPadding(horizontal = 16.dp),
                     categoryItemList = menu.categoryItemList,
                     menuItemList = menu.menuItemList,
+                    hasFavoritesSection = menu.hasFavoritesSection,
                     menuLazyGridState = menuLazyListState,
                     onAction = onAction,
                 )
@@ -202,6 +203,23 @@ internal fun MenuColumn(
                             lastOrder = lastOrder,
                         )
                     }
+                }
+            }
+
+            if (menu.hasFavoritesSection) {
+                item(
+                    key = "Favorites",
+                    span = {
+                        GridItemSpan(maxLineSpan)
+                    },
+                ) {
+                    MenuFavoritesRow(
+                        modifier = Modifier.fillMaxWidth()
+                            .ignoreHorizontalParentPadding(horizontal = 16.dp),
+                        products = menu.favoriteProductList,
+                        animatedContentScope = animatedContentScope,
+                        onAction = onAction,
+                    )
                 }
             }
 

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuFavoritesRow.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuFavoritesRow.kt
@@ -1,0 +1,80 @@
+package com.bunbeauty.menu.ui
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.bunbeauty.core.model.ProductUi
+import com.bunbeauty.designsystem.theme.FoodDeliveryTheme
+import com.bunbeauty.designsystem.theme.bold
+import com.bunbeauty.designsystem.ui.element.FoodDeliveryProductItem
+import com.bunbeauty.menu.presentation.MenuState
+import kotlinx.collections.immutable.ImmutableList
+import org.jetbrains.compose.resources.stringResource
+import papakarlo.designsystem.generated.resources.Res
+import papakarlo.designsystem.generated.resources.title_favorites
+
+private val FavoriteProductCardWidth = 180.dp
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+internal fun MenuFavoritesRow(
+    products: ImmutableList<ProductUi>,
+    animatedContentScope: AnimatedVisibilityScope,
+    onAction: (MenuState.Action) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(
+            modifier =
+                Modifier.padding(
+                    top = 16.dp,
+                    start = 16.dp,
+                    end = 16.dp
+                ),
+            text = stringResource(resource = Res.string.title_favorites),
+            style = FoodDeliveryTheme.typography.titleMedium.bold,
+            color = FoodDeliveryTheme.colors.mainColors.onSurface,
+        )
+        LazyRow(
+            modifier =
+                Modifier
+                    .padding(top = 12.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(
+                items = products,
+                key = { product -> product.key },
+            ) { product ->
+                FoodDeliveryProductItem(
+                    modifier = Modifier.width(FavoriteProductCardWidth),
+                    animatedContentScope = animatedContentScope,
+                    onAddProductClick = { menuProductUuid ->
+                        onAction(MenuState.Action.OnAddProductClicked(menuProductUuid))
+                    },
+                    onProductClick = { menuProductUuid ->
+                        onAction(MenuState.Action.OnMenuItemClicked(menuProductUuid))
+                    },
+                    uuid = product.uuid,
+                    photoLink = product.photoLink,
+                    name = product.name,
+                    oldPrice = product.oldPrice,
+                    newPrice = product.newPrice,
+                )
+            }
+        }
+    }
+}

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuRoute.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuRoute.kt
@@ -52,6 +52,7 @@ fun MenuRoute(
 
     LifecycleStartEffect(Unit) {
         onAction(MenuState.Action.StartLastOrderObservation)
+        onAction(MenuState.Action.RefreshFavorites)
         onStopOrDispose {
             onAction(MenuState.Action.StopLastOrderObservation)
         }

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuScreen.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuScreen.kt
@@ -163,6 +163,8 @@ private fun MenuScreenSuccessPreview() {
                                 getCategoryItem("5"),
                                 getCategoryItem("6"),
                             ),
+                        favoriteProductList = persistentListOf(),
+                        hasFavoritesSection = false,
                         menuItemList =
                             persistentListOf(
                                 getMenuCategoryHeaderItem("4"),
@@ -212,6 +214,8 @@ private fun MenuScreenLoadingPreview() {
                 viewState =
                     MenuViewState(
                         categoryItemList = persistentListOf(),
+                        favoriteProductList = persistentListOf(),
+                        hasFavoritesSection = false,
                         topCartUi =
                             TopCartUi(
                                 cost = "100",
@@ -239,6 +243,8 @@ private fun MenuScreenErrorPreview() {
                 viewState =
                     MenuViewState(
                         categoryItemList = persistentListOf(),
+                        favoriteProductList = persistentListOf(),
+                        hasFavoritesSection = false,
                         topCartUi =
                             TopCartUi(
                                 cost = "100",

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/mapper/MenuStateMapper.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/mapper/MenuStateMapper.kt
@@ -5,14 +5,23 @@ import com.bunbeauty.core.model.CategoryItem
 import com.bunbeauty.core.model.MenuItem
 import com.bunbeauty.core.model.ProductUi
 import com.bunbeauty.designsystem.ui.element.TopCartUi
-import com.bunbeauty.menu.presentation.MENU_FIRST_CONTENT_GRID_INDEX
+import com.bunbeauty.menu.presentation.MENU_GRID_INDEX_FAVORITES
 import com.bunbeauty.menu.presentation.MenuState
+import com.bunbeauty.menu.presentation.menuContentStartGridIndex
 import com.bunbeauty.menu.ui.state.MenuItemUi
 import com.bunbeauty.menu.ui.state.MenuViewState
 import kotlinx.collections.immutable.toImmutableList
 
-fun MenuState.DataState.mapState(): MenuViewState =
-    MenuViewState(
+fun MenuState.DataState.mapState(): MenuViewState {
+    val favoriteProducts =
+        favoriteProductList
+            .map { menuProduct ->
+                menuProduct.toMenuProductItemUi()
+            }.map { menuItemUi ->
+                menuItemUi.product
+            }.toImmutableList()
+
+    return MenuViewState(
         topCartUi =
             TopCartUi(
                 cost =
@@ -27,6 +36,8 @@ fun MenuState.DataState.mapState(): MenuViewState =
                 .map { menuItem ->
                     menuItem.toMenuItemUi()
                 }.toImmutableList(),
+        favoriteProductList = favoriteProducts,
+        hasFavoritesSection = favoriteProducts.isNotEmpty(),
         state =
             when (state) {
                 MenuState.DataState.State.LOADING -> MenuViewState.State.Loading
@@ -36,16 +47,27 @@ fun MenuState.DataState.mapState(): MenuViewState =
         userScrollEnabled = userScrollEnabled,
         lastOrder = lastOrder,
     )
+}
 
 fun getMenuListPosition(
     categoryItem: CategoryItem,
     menuItemList: List<MenuItemUi>,
+    hasFavoritesSection: Boolean,
 ): Int {
+    if (categoryItem.uuid == com.bunbeauty.core.Constants.FAVORITES_CATEGORY_UUID) {
+        return MENU_GRID_INDEX_FAVORITES
+    }
+
     val indexInMenuList =
         menuItemList.indexOfFirst { menuItem ->
             (menuItem as? MenuItemUi.CategoryHeader)?.uuid == categoryItem.uuid
         }
-    return if (indexInMenuList < 0) 0 else indexInMenuList + MENU_FIRST_CONTENT_GRID_INDEX
+    val startIndex = menuContentStartGridIndex(hasFavoritesSection = hasFavoritesSection)
+    return if (indexInMenuList < 0) {
+        startIndex
+    } else {
+        indexInMenuList + startIndex
+    }
 }
 
 fun MenuItem.Product.toMenuProductItemUi(): MenuItemUi.Product {

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/state/MenuViewState.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/state/MenuViewState.kt
@@ -13,6 +13,8 @@ data class MenuViewState(
     val categoryItemList: ImmutableList<CategoryItem>,
     val topCartUi: TopCartUi,
     val menuItemList: ImmutableList<MenuItemUi>,
+    val favoriteProductList: ImmutableList<ProductUi>,
+    val hasFavoritesSection: Boolean,
     val state: State,
     val userScrollEnabled: Boolean,
     val lastOrder: LightOrder?,

--- a/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/di/ProductDetailsFeatureModule.kt
+++ b/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/di/ProductDetailsFeatureModule.kt
@@ -15,6 +15,10 @@ fun productDetailsFeatureModule() =
                 editCartProductUseCase = get(),
                 getAdditionGroupsWithSelectedAdditionUseCase = get(),
                 getSelectedAdditionsPriceUseCase = get(),
+                observeTokenUseCase = get(),
+                loadFavoritesUseCase = get(),
+                isProductFavoriteUseCase = get(),
+                toggleFavoriteUseCase = get(),
             )
         }
     }

--- a/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/presentation/ProductDetailsState.kt
+++ b/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/presentation/ProductDetailsState.kt
@@ -12,6 +12,8 @@ interface ProductDetailsState {
         val cartCostAndCount: CartCostAndCount?,
         val menuProduct: MenuProduct,
         val screenState: ScreenState,
+        val isAuthorized: Boolean = false,
+        val isFavorite: Boolean = false,
     ) : BaseDataState {
         data class MenuProduct(
             val uuid: String,
@@ -54,6 +56,8 @@ interface ProductDetailsState {
             val productDetailsOpenedFrom: ProductDetailsOpenedFrom,
             val cartProductUuid: String?,
         ) : Action
+
+        data object FavoriteClick : Action
     }
 
     sealed interface Event : BaseEvent {
@@ -64,5 +68,7 @@ interface ProductDetailsState {
         data object EditedProduct : Event
 
         data object ShowAddProductError : Event
+
+        data object ShowFavoriteError : Event
     }
 }

--- a/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/presentation/ProductDetailsViewModel.kt
+++ b/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/presentation/ProductDetailsViewModel.kt
@@ -2,6 +2,8 @@ package com.bunbeauty.productdetails.presentation
 
 import com.bunbeauty.analytic.AnalyticService
 import com.bunbeauty.analytic.event.cart.AddCartProductDetailsClickEvent
+import com.bunbeauty.analytic.event.favorite.AddFavoriteClickEvent
+import com.bunbeauty.analytic.event.favorite.RemoveFavoriteClickEvent
 import com.bunbeauty.analytic.event.menu.AddMenuProductDetailsClickEvent
 import com.bunbeauty.analytic.event.recommendation.AddRecommendationProductDetailsClickEvent
 import com.bunbeauty.analytic.parameter.MenuProductUuidEventParameter
@@ -109,6 +111,10 @@ class ProductDetailsViewModel(
         sharedScope.launchSafe(
             block = {
                 val isFavorite = toggleFavoriteUseCase(menuProductUuid = menuProductUuid)
+                sendFavoriteToggleAnalytic(
+                    menuProductUuid = menuProductUuid,
+                    isFavorite = isFavorite,
+                )
                 setState {
                     copy(isFavorite = isFavorite)
                 }
@@ -121,6 +127,26 @@ class ProductDetailsViewModel(
                     ProductDetailsState.Event.ShowFavoriteError
                 }
             },
+        )
+    }
+
+    private fun sendFavoriteToggleAnalytic(
+        menuProductUuid: String,
+        isFavorite: Boolean,
+    ) {
+        val menuProductUuidEventParameter =
+            MenuProductUuidEventParameter(value = menuProductUuid)
+        analyticService.sendEvent(
+            event =
+                if (isFavorite) {
+                    AddFavoriteClickEvent(
+                        menuProductUuidEventParameter = menuProductUuidEventParameter,
+                    )
+                } else {
+                    RemoveFavoriteClickEvent(
+                        menuProductUuidEventParameter = menuProductUuidEventParameter,
+                    )
+                },
         )
     }
 

--- a/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/presentation/ProductDetailsViewModel.kt
+++ b/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/presentation/ProductDetailsViewModel.kt
@@ -10,8 +10,12 @@ import com.bunbeauty.core.base.SharedStateViewModel
 import com.bunbeauty.core.domain.ObserveCartUseCase
 import com.bunbeauty.core.domain.addition.GetAdditionGroupsWithSelectedAdditionUseCase
 import com.bunbeauty.core.domain.addition.GetPriceOfSelectedAdditionsUseCase
+import com.bunbeauty.core.domain.auth.ObserveTokenUseCase
 import com.bunbeauty.core.domain.cart.AddCartProductUseCase
 import com.bunbeauty.core.domain.cart.EditCartProductUseCase
+import com.bunbeauty.core.domain.favorite.IsProductFavoriteUseCase
+import com.bunbeauty.core.domain.favorite.LoadFavoritesUseCase
+import com.bunbeauty.core.domain.favorite.ToggleFavoriteUseCase
 import com.bunbeauty.core.domain.menu_product.GetMenuProductUseCase
 import com.bunbeauty.core.extension.launchSafe
 import com.bunbeauty.core.model.ProductDetailsOpenedFrom
@@ -28,6 +32,10 @@ class ProductDetailsViewModel(
     private val editCartProductUseCase: EditCartProductUseCase,
     private val getAdditionGroupsWithSelectedAdditionUseCase: GetAdditionGroupsWithSelectedAdditionUseCase,
     private val getSelectedAdditionsPriceUseCase: GetPriceOfSelectedAdditionsUseCase,
+    private val observeTokenUseCase: ObserveTokenUseCase,
+    private val loadFavoritesUseCase: LoadFavoritesUseCase,
+    private val isProductFavoriteUseCase: IsProductFavoriteUseCase,
+    private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
 ) : SharedStateViewModel<ProductDetailsState.DataState, ProductDetailsState.Action, ProductDetailsState.Event>(
         ProductDetailsState.DataState(
             cartCostAndCount = null,
@@ -53,6 +61,8 @@ class ProductDetailsViewModel(
     }
 
     private var observeConsumerCartJob: Job? = null
+    private var observeTokenJob: Job? = null
+    private var currentMenuProductUuid: String = ""
 
     override fun reduce(
         action: ProductDetailsState.Action,
@@ -77,13 +87,82 @@ class ProductDetailsViewModel(
                 )
 
             is ProductDetailsState.Action.Init -> {
+                currentMenuProductUuid = action.menuProductUuid
                 observeCart()
+                observeToken()
                 getMenuProduct(
                     menuProductUuid = action.menuProductUuid,
                     selectedAdditionUuidList = action.selectedAdditionUuidList,
                 )
             }
+
+            ProductDetailsState.Action.FavoriteClick -> onFavoriteClick()
         }
+    }
+
+    private fun onFavoriteClick() {
+        val menuProductUuid = dataState.value.menuProduct.uuid
+        val previousFavorite = dataState.value.isFavorite
+        setState {
+            copy(isFavorite = !isFavorite)
+        }
+        sharedScope.launchSafe(
+            block = {
+                val isFavorite = toggleFavoriteUseCase(menuProductUuid = menuProductUuid)
+                setState {
+                    copy(isFavorite = isFavorite)
+                }
+            },
+            onError = {
+                setState {
+                    copy(isFavorite = previousFavorite)
+                }
+                addEvent {
+                    ProductDetailsState.Event.ShowFavoriteError
+                }
+            },
+        )
+    }
+
+    private fun observeToken() {
+        observeTokenJob?.cancel()
+
+        observeTokenJob =
+            sharedScope.launchSafe(
+                block = {
+                    observeTokenUseCase().collectLatest { token ->
+                        val isAuthorized = token != null
+                        setState {
+                            copy(isAuthorized = isAuthorized)
+                        }
+                        if (isAuthorized) {
+                            loadFavoriteState(menuProductUuid = currentMenuProductUuid)
+                        } else {
+                            setState {
+                                copy(isFavorite = false)
+                            }
+                        }
+                    }
+                },
+                onError = { },
+            )
+    }
+
+    private fun loadFavoriteState(menuProductUuid: String) {
+        if (menuProductUuid.isEmpty()) {
+            return
+        }
+
+        sharedScope.launchSafe(
+            block = {
+                loadFavoritesUseCase()
+                val isFavorite = isProductFavoriteUseCase(menuProductUuid = menuProductUuid)
+                setState {
+                    copy(isFavorite = isFavorite)
+                }
+            },
+            onError = { },
+        )
     }
 
     private fun selectAddition(

--- a/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/ui/ProductDetailsRoute.kt
+++ b/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/ui/ProductDetailsRoute.kt
@@ -41,6 +41,7 @@ import com.bunbeauty.designsystem.theme.bold
 import com.bunbeauty.designsystem.ui.LocalBottomBarPadding
 import com.bunbeauty.designsystem.ui.SharedTransitionScopeComposition
 import com.bunbeauty.designsystem.ui.element.FoodDeliveryAsyncImage
+import com.bunbeauty.designsystem.ui.element.FoodDeliveryAction
 import com.bunbeauty.designsystem.ui.element.FoodDeliveryScaffold
 import com.bunbeauty.designsystem.ui.element.TopCartUi
 import com.bunbeauty.designsystem.ui.element.addition.AdditionCardItem
@@ -63,6 +64,10 @@ import papakarlo.designsystem.generated.resources.action_product_details_want
 import papakarlo.designsystem.generated.resources.common_error
 import papakarlo.designsystem.generated.resources.description_product
 import papakarlo.designsystem.generated.resources.error_consumer_cart_add_product
+import papakarlo.designsystem.generated.resources.description_favorite
+import papakarlo.designsystem.generated.resources.error_something_went_wrong
+import papakarlo.designsystem.generated.resources.ic_favorite_24
+import papakarlo.designsystem.generated.resources.ic_favorite_filled_24
 import papakarlo.designsystem.generated.resources.ic_plus_16
 import papakarlo.designsystem.generated.resources.msg_menu_product_added
 import papakarlo.designsystem.generated.resources.msg_menu_product_edited
@@ -168,6 +173,12 @@ fun ProductDetailsEffect(
                     )
                     back()
                 }
+
+                ProductDetailsState.Event.ShowFavoriteError -> {
+                    showErrorMessage(
+                        getString(resource = Res.string.error_something_went_wrong),
+                    )
+                }
             }
         }
         consumeEffects()
@@ -192,6 +203,32 @@ private fun ProductDetailsScreen(
         backActionClick = {
             onAction(ProductDetailsState.Action.BackClick)
         },
+        topActions =
+            if (productDetailsViewState is ProductDetailsViewState.Success && productDetailsViewState.isAuthorized) {
+                val isFavorite = productDetailsViewState.isFavorite
+                persistentListOf(
+                    FoodDeliveryAction(
+                        iconId =
+                            if (isFavorite) {
+                                Res.drawable.ic_favorite_filled_24
+                            } else {
+                                Res.drawable.ic_favorite_24
+                            },
+                        tint =
+                            if (isFavorite) {
+                                FoodDeliveryTheme.colors.mainColors.primary
+                            } else {
+                                null
+                            },
+                        contentDescriptionId = Res.string.description_favorite,
+                        onClick = {
+                            onAction(ProductDetailsState.Action.FavoriteClick)
+                        },
+                    ),
+                )
+            } else {
+                persistentListOf()
+            },
         actionButton = {
             if (productDetailsViewState is ProductDetailsViewState.Success) {
                 FoodDeliveryExtendedFab(
@@ -484,6 +521,8 @@ private fun ProductDetailsSuccessScreenPreview() {
                                     cost = "100",
                                     count = "2",
                                 ),
+                            isAuthorized = true,
+                            isFavorite = true,
                             menuProductUi =
                                 ProductDetailsViewState.Success.MenuProductUi(
                                     photoLink = "",

--- a/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/ui/ProductDetailsUiStateMapper.kt
+++ b/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/ui/ProductDetailsUiStateMapper.kt
@@ -76,6 +76,8 @@ fun ProductDetailsState.DataState.map(): ProductDetailsViewState {
                                 }.orEmpty(),
                         count = cartCostAndCount?.count.orEmpty(),
                     ),
+                isAuthorized = isAuthorized,
+                isFavorite = isFavorite,
                 menuProductUi =
                     menuProduct.let { menuProduct ->
                         ProductDetailsViewState.Success.MenuProductUi(

--- a/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/ui/ProductDetailsViewState.kt
+++ b/feature/productdetails/src/commonMain/kotlin/com/bunbeauty/productdetails/ui/ProductDetailsViewState.kt
@@ -12,6 +12,8 @@ sealed interface ProductDetailsViewState : BaseViewState {
     data class Success(
         val topCartUi: TopCartUi,
         val menuProductUi: MenuProductUi,
+        val isAuthorized: Boolean,
+        val isFavorite: Boolean,
     ) : ProductDetailsViewState {
         @Immutable
         data class MenuProductUi(

--- a/shared/shared.podspec
+++ b/shared/shared.podspec
@@ -35,18 +35,13 @@ Pod::Spec.new do |spec|
                     exit 0
                 fi
                 set -ev
-                if [ "$PLATFORM_NAME" = "iphonesimulator" ]; then
-                    KOTLIN_ARCHS="arm64"
-                else
-                    KOTLIN_ARCHS="$ARCHS"
-                fi
                 REPO_ROOT="$PODS_TARGET_SRCROOT"
                 "$REPO_ROOT/../gradlew" -p "$REPO_ROOT" $KOTLIN_PROJECT_PATH:syncFramework \
                     -Pkotlin.native.cocoapods.platform=$PLATFORM_NAME \
-                    -Pkotlin.native.cocoapods.archs="$KOTLIN_ARCHS" \
+                    -Pkotlin.native.cocoapods.archs="$ARCHS" \
                     -Pkotlin.native.cocoapods.configuration="$CONFIGURATION"
             SCRIPT
         }
     ]
-    spec.resources = ['build/compose/cocoapods/compose-resources']
+    spec.resources = ['build\compose\cocoapods\compose-resources']
 end

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/di/RepositoryModule.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/di/RepositoryModule.kt
@@ -10,6 +10,7 @@ import com.bunbeauty.core.domain.repo.CityRepo
 import com.bunbeauty.core.domain.repo.CompanyRepo
 import com.bunbeauty.core.domain.repo.CreateOrderSettingsRepo
 import com.bunbeauty.core.domain.repo.DiscountRepo
+import com.bunbeauty.core.domain.repo.FavoriteRepo
 import com.bunbeauty.core.domain.repo.LinkRepo
 import com.bunbeauty.core.domain.repo.MenuProductRepo
 import com.bunbeauty.core.domain.repo.OrderRepo
@@ -33,6 +34,7 @@ import com.bunbeauty.shared.data.repository.CityRepository
 import com.bunbeauty.shared.data.repository.CompanyRepository
 import com.bunbeauty.shared.data.repository.CreateOrderSettingsRepository
 import com.bunbeauty.shared.data.repository.DiscountRepository
+import com.bunbeauty.shared.data.repository.FavoriteRepository
 import com.bunbeauty.shared.data.repository.LinkRepository
 import com.bunbeauty.shared.data.repository.MenuProductRepository
 import com.bunbeauty.shared.data.repository.OrderRepository
@@ -168,6 +170,12 @@ fun repositoryModule() =
             DiscountRepository(
                 networkConnector = get(),
                 dataStoreRepo = get(),
+            )
+        }
+        single<FavoriteRepo> {
+            FavoriteRepository(
+                networkConnector = get(),
+                userRepo = get(),
             )
         }
         single<AuthRepo> {

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/network/api/NetworkConnector.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/network/api/NetworkConnector.kt
@@ -6,6 +6,8 @@ import com.bunbeauty.shared.data.network.model.CafeServer
 import com.bunbeauty.shared.data.network.model.CategoryServer
 import com.bunbeauty.shared.data.network.model.CityServer
 import com.bunbeauty.shared.data.network.model.DiscountServer
+import com.bunbeauty.shared.data.network.model.FavoriteServer
+import com.bunbeauty.shared.data.network.model.PostFavoriteServer
 import com.bunbeauty.shared.data.network.model.ForceUpdateVersionServer
 import com.bunbeauty.shared.data.network.model.LinkServer
 import com.bunbeauty.shared.data.network.model.ListServer
@@ -80,6 +82,18 @@ interface NetworkConnector {
     suspend fun getLinkList(): ApiResult<ListServer<LinkServer>>
 
     suspend fun getRecommendationData(): ApiResult<RecommendationDataServer>
+
+    suspend fun getFavoriteList(token: String): ApiResult<ListServer<FavoriteServer>>
+
+    suspend fun postFavorite(
+        token: String,
+        body: PostFavoriteServer,
+    ): ApiResult<FavoriteServer>
+
+    suspend fun deleteFavorite(
+        token: String,
+        menuProductUuid: String,
+    ): ApiResult<Unit>
 
     suspend fun postUserAddress(
         token: String,

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/network/api/NetworkConnectorImpl.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/network/api/NetworkConnectorImpl.kt
@@ -15,6 +15,8 @@ import com.bunbeauty.shared.data.network.model.CafeServer
 import com.bunbeauty.shared.data.network.model.CategoryServer
 import com.bunbeauty.shared.data.network.model.CityServer
 import com.bunbeauty.shared.data.network.model.DiscountServer
+import com.bunbeauty.shared.data.network.model.FavoriteServer
+import com.bunbeauty.shared.data.network.model.PostFavoriteServer
 import com.bunbeauty.shared.data.network.model.ForceUpdateVersionServer
 import com.bunbeauty.shared.data.network.model.LinkServer
 import com.bunbeauty.shared.data.network.model.ListServer
@@ -44,6 +46,7 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -206,6 +209,13 @@ internal class NetworkConnectorImpl(
             parameters = mapOf(COMPANY_UUID_PARAMETER to companyUuidProvider.companyUuid),
         )
 
+    override suspend fun getFavoriteList(token: String): ApiResult<ListServer<FavoriteServer>> =
+        getData(
+            path = "v2/client/favorite",
+            parameters = mapOf(COMPANY_UUID_PARAMETER to companyUuidProvider.companyUuid),
+            token = token,
+        )
+
     // POST
     override suspend fun postUserAddress(
         token: String,
@@ -234,6 +244,17 @@ internal class NetworkConnectorImpl(
         postData(
             path = "v5/order",
             body = order,
+            token = token,
+        )
+
+    override suspend fun postFavorite(
+        token: String,
+        body: PostFavoriteServer,
+    ): ApiResult<FavoriteServer> =
+        postData(
+            path = "v2/client/favorite",
+            parameters = mapOf(COMPANY_UUID_PARAMETER to companyUuidProvider.companyUuid),
+            body = body,
             token = token,
         )
 
@@ -272,6 +293,18 @@ internal class NetworkConnectorImpl(
             path = "client/code_check",
             body = code,
             parameters = mapOf(UUID_PARAMETER to uuid),
+        )
+
+    // DELETE
+
+    override suspend fun deleteFavorite(
+        token: String,
+        menuProductUuid: String,
+    ): ApiResult<Unit> =
+        deleteData(
+            path = "v2/client/favorite/$menuProductUuid",
+            parameters = mapOf(COMPANY_UUID_PARAMETER to companyUuidProvider.companyUuid),
+            token = token,
         )
 
     // WEB_SOCKET
@@ -361,6 +394,35 @@ internal class NetworkConnectorImpl(
                     timeout = timeout,
                 )
             }
+        }
+
+    private suspend fun deleteData(
+        path: String,
+        parameters: Map<String, Any> = mapOf(),
+        token: String? = null,
+        timeout: Long = COMMON_TIMEOUT,
+    ): ApiResult<Unit> =
+        try {
+            client.delete {
+                buildRequest(
+                    path = path,
+                    parameters = parameters,
+                    token = token,
+                    timeout = timeout,
+                )
+            }
+            ApiResult.Success(Unit)
+        } catch (exception: FoodDeliveryNetworkException) {
+            throw exception
+        } catch (exception: ClientRequestException) {
+            val code = exception.response.status.value
+            val message = exception.message
+            errorLogger.logWarning(code = code, message = message, throwable = exception)
+            ApiResult.Error(ApiError(code, message))
+        } catch (exception: Throwable) {
+            val message = exception.message.toString()
+            errorLogger.logWarning(code = 0, message = message, throwable = exception)
+            ApiResult.Error(ApiError(0, message))
         }
 
     private suspend inline fun <reified R> safeCall(networkCall: () -> HttpResponse): ApiResult<R> =

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/network/model/FavoriteServer.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/network/model/FavoriteServer.kt
@@ -1,0 +1,26 @@
+package com.bunbeauty.shared.data.network.model
+
+import com.bunbeauty.core.model.Favorite
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FavoriteServer(
+    @SerialName("menuProductUuid")
+    val menuProductUuid: String,
+    @SerialName("createdAt")
+    val createdAt: String,
+)
+
+@Serializable
+data class PostFavoriteServer(
+    @SerialName("menuProductUuid")
+    val menuProductUuid: String,
+)
+
+fun FavoriteServer.toFavorite(): Favorite =
+    Favorite(
+        menuProductUuid = menuProductUuid,
+        createdAtMillis = Instant.parse(createdAt).toEpochMilliseconds(),
+    )

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/repository/FavoriteRepository.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/repository/FavoriteRepository.kt
@@ -1,0 +1,91 @@
+package com.bunbeauty.shared.data.repository
+
+import com.bunbeauty.core.domain.exeptions.NoTokenException
+import com.bunbeauty.core.domain.repo.FavoriteRepo
+import com.bunbeauty.core.domain.repo.UserRepo
+import com.bunbeauty.core.extension.getNullableResult
+import com.bunbeauty.core.extension.map
+import com.bunbeauty.core.model.Favorite
+import com.bunbeauty.shared.data.network.api.NetworkConnector
+import com.bunbeauty.shared.data.network.model.PostFavoriteServer
+import com.bunbeauty.shared.data.network.model.toFavorite
+
+class FavoriteRepository(
+    private val networkConnector: NetworkConnector,
+    private val userRepo: UserRepo,
+) : CacheListRepository<Favorite>(),
+    FavoriteRepo {
+    override val tag: String = "FAVORITE_TAG"
+
+    override suspend fun getFavoriteList(): List<Favorite> {
+        val token = userRepo.getToken() ?: return emptyList()
+
+        return getCacheOrListData(
+            onApiRequest = {
+                networkConnector.getFavoriteList(token = token)
+            },
+            onLocalRequest = {
+                emptyList()
+            },
+            onSaveLocally = { },
+            serverToDomainModel = { favoriteServer ->
+                favoriteServer.toFavorite()
+            },
+        )
+    }
+
+    override suspend fun isFavorite(menuProductUuid: String): Boolean =
+        getFavoriteList().any { favorite ->
+            favorite.menuProductUuid == menuProductUuid
+        }
+
+    override suspend fun addFavorite(menuProductUuid: String) {
+        val token = userRepo.getToken() ?: throw NoTokenException()
+
+        networkConnector
+            .postFavorite(
+                token = token,
+                body = PostFavoriteServer(menuProductUuid = menuProductUuid),
+            ).getNullableResult(
+                onError = { apiError ->
+                    throw IllegalStateException(apiError.message)
+                },
+                onSuccess = { favoriteServer ->
+                    updateCache { favoriteList ->
+                        val favorite = favoriteServer.toFavorite()
+                        val currentList = favoriteList ?: emptyList()
+                        if (currentList.any { item -> item.menuProductUuid == menuProductUuid }) {
+                            currentList
+                        } else {
+                            currentList + favorite
+                        }
+                    }
+                },
+            )
+    }
+
+    override suspend fun removeFavorite(menuProductUuid: String) {
+        val token = userRepo.getToken() ?: throw NoTokenException()
+
+        networkConnector
+            .deleteFavorite(
+                token = token,
+                menuProductUuid = menuProductUuid,
+            ).map(
+                onError = { apiError ->
+                    throw IllegalStateException(apiError.message)
+                },
+                onSuccess = {
+                    updateCache { favoriteList ->
+                        favoriteList?.filter { favorite ->
+                            favorite.menuProductUuid != menuProductUuid
+                        }
+                    }
+                },
+            )
+    }
+
+    override suspend fun clearCache() {
+        cache = null
+    }
+}

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/InteractorModule.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/InteractorModule.kt
@@ -21,6 +21,7 @@ internal fun interactorModule() =
                 cafeRepo = get(),
                 userAddressRepo = get(),
                 createOrderSettingsRepo = get(),
+                favoriteRepo = get(),
             )
         }
         single<ICityInteractor> {

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/Koin.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/Koin.kt
@@ -43,6 +43,7 @@ import com.bunbeauty.core.domain.cart.ICartProductInteractor
 import com.bunbeauty.core.domain.cart.IncreaseCartProductCountUseCase
 import com.bunbeauty.core.domain.cart.RemoveCartProductUseCase
 import com.bunbeauty.core.domain.cart.di.cartModule
+import com.bunbeauty.core.domain.favorite.di.favoriteModule
 import com.bunbeauty.core.domain.city.GetCityListUseCase
 import com.bunbeauty.core.domain.city.GetSelectedCityTimeZoneUseCase
 import com.bunbeauty.core.domain.city.ICityInteractor
@@ -124,6 +125,7 @@ fun initKoin(appDeclaration: KoinAppDeclaration = {}) =
             userAddressUseCaseModule(),
             orderUseCaseModule(),
             cartModule(),
+            favoriteModule(),
             cafeModule(),
             paymentUseCaseModule(),
             authUseCaseModule(),
@@ -167,6 +169,7 @@ fun initKoin() =
             userAddressUseCaseModule(),
             orderUseCaseModule(),
             cartModule(),
+            favoriteModule(),
             cafeModule(),
             paymentUseCaseModule(),
             authUseCaseModule(),


### PR DESCRIPTION
## Summary

### Product Details — избранное
- API `/v2/client/favorite` (GET/POST/DELETE) через `NetworkConnector`
- `FavoriteRepository` с in-memory кэшем (паттерн `CacheListRepository`)
- Domain: модель `Favorite`, `FavoriteRepo`, `LoadFavoritesUseCase`, `IsProductFavoriteUseCase`, `ToggleFavoriteUseCase`, `favoriteModule()`
- ProductDetails: иконка сердца в тулбаре (outline/filled), optimistic UI с откатом при ошибке
- Неавторизованным пользователям иконка избранного скрыта
- При logout кэш избранного очищается через `UserInteractor.clearUserCache()`

### Menu — секция «Избранные»
- Горизонтальный `LazyRow` с карточками `FoodDeliveryProductItem` перед основными категориями
- Заголовок «Избранные» (`title_favorites`)
- Псевдо-категория в ряду категорий для скролла к секции
- `GetFavoriteMenuProductsUseCase` объединяет избранное и продукты меню, сортировка по `createdAt` (новые первыми)
- Секция скрыта, если пользователь не залогинен или список избранного пуст
- Обновление избранного при старте экрана Menu (возврат с ProductDetails)
- Исправления `MenuGridIndex` для корректных индексов скролла при видимой секции избранного

### Analytics
- `AddFavoriteClickEvent` (`vkuskavkaza_favorite_add`) — category=favorite, action=add
- `RemoveFavoriteClickEvent` (`vkuskavkaza_favorite_remove`) — category=favorite, action=remove
- Параметр: `menu_product_uuid`
- Отправка из `ProductDetailsViewModel` после успешного toggle

### UI assets
- `ic_favorite_24.xml`, `ic_favorite_filled_24.xml`
- `FoodDeliveryAction` поддерживает опциональные `tint` и `contentDescriptionId`

## Test plan

- [ ] **ProductDetails — toggle избранного**: открыть карточку блюда, нажать сердце — иконка меняется на filled; повторное нажатие — обратно на outline; после перезахода на экран состояние сохраняется
- [ ] **Ошибка сети**: при ошибке API toggle откатывается к предыдущему состоянию
- [ ] **Неавторизованный пользователь**: иконка избранного на ProductDetails не отображается; секция «Избранные» в меню скрыта
- [ ] **Menu — секция «Избранные»**: после добавления блюда в избранное на ProductDetails вернуться в меню — горизонтальный ряд с карточками и заголовком «Избранные»; порядок — новые первыми
- [ ] **Псевдо-категория**: тап по чипу «Избранные» в ряду категорий скроллит к секции избранного
- [ ] **Пустой список**: удалить все избранное — секция в меню скрывается
- [ ] **Logout**: после выхода кэш очищается, избранное не отображается до повторного входа
- [ ] **Analytics**: при add/remove проверить события `vkuskavkaza_favorite_add` / `vkuskavkaza_favorite_remove` с параметром `menu_product_uuid`