### PR TITLE
Fix iOS Release launch crash (Firebase before Koin)

### DIFF
--- a/.github/workflows/publish-workflow-ios.yml
+++ b/.github/workflows/publish-workflow-ios.yml
@@ -76,6 +76,50 @@ jobs:
           tar -xzf firebase-plists.tar.gz
           rm firebase-plists.tar.gz
 
+      - name: "Verify GoogleService-Info.plist for publish apps"
+        run: |
+          set -euo pipefail
+          # scheme_key|res_folder|expected_BUNDLE_ID (same set as Fastfile `apps` / submit matrix)
+          APPS=(
+            "papakarlo|papakarloRes|com.bunbeuaty.papakarlo"
+            "gustopub|gustoPubRes|com.bunbeauty.gustopub"
+            "yuliar|yuliarRes|com.bunbeauty.yuliar"
+            "tandirhouse|tandirHouseRes|com.bunbeauty.tandirhouse"
+            "vkuskavkaza|vkusKavkazaRes|com.bunbeauty.vkuskavkaza"
+            "djan|djanRes|com.bunbeauty.djan"
+            "usaba|usadbaRes|com.bunbeauty.usadba"
+            "emoji|emojiRes|com.bunbeauty.emoji"
+            "estpoest|estpoestRes|com.bunbeauty.estpoest"
+            "taverna|tavernaRes|com.bunbeauty.taverna"
+            "voljane|voljaneRes|com.bunbeauty.voljane"
+          )
+          missing=0
+          for entry in "${APPS[@]}"; do
+            IFS='|' read -r name res expected_bundle <<< "$entry"
+            plist="iosApp/iosApp/${res}/GoogleService-Info.plist"
+            if [ ! -f "$plist" ]; then
+              echo "::error::Missing $plist (app=$name)"
+              missing=1
+              continue
+            fi
+            actual_bundle=$(/usr/libexec/PlistBuddy -c 'Print :BUNDLE_ID' "$plist" 2>/dev/null || true)
+            if [ -z "$actual_bundle" ]; then
+              echo "::error::No BUNDLE_ID in $plist (app=$name)"
+              missing=1
+              continue
+            fi
+            if [ "$actual_bundle" != "$expected_bundle" ]; then
+              echo "::error::BUNDLE_ID mismatch for $name: expected=$expected_bundle actual=$actual_bundle ($plist)"
+              missing=1
+              continue
+            fi
+            echo "OK $name: $plist ($actual_bundle)"
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::One or more GoogleService-Info.plist checks failed. Update secret IOS_FIREBASE_PLISTS_TAR_BASE64."
+            exit 1
+          fi
+
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/analytic/src/iosMain/kotlin/com/bunbeauty/analytic/di/AnalyticModule.kt
+++ b/analytic/src/iosMain/kotlin/com/bunbeauty/analytic/di/AnalyticModule.kt
@@ -1,19 +1,10 @@
-@file:OptIn(ExperimentalForeignApi::class)
-
 package com.bunbeauty.analytic.di
 
-import cocoapods.FirebaseAnalytics.FIRAnalytics
 import com.bunbeauty.analytic.AnalyticService
-import com.bunbeauty.core.isDebugQualifier
-import kotlinx.cinterop.ExperimentalForeignApi
 import org.koin.dsl.module
 
 actual fun analyticModule() =
     module {
-        single(createdAtStart = true) {
-            val isDebug: Boolean = get(isDebugQualifier)
-            FIRAnalytics.setAnalyticsCollectionEnabled(!isDebug)
-        }
         factory {
             AnalyticService()
         }

--- a/iosApp/iosApp/AppDelegate.swift
+++ b/iosApp/iosApp/AppDelegate.swift
@@ -31,7 +31,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         }
 
         application.registerForRemoteNotifications()
-        FirebaseApp.configure()
+        // Firebase is configured in PapaKarloSwiftApp.init before Koin.
+        // Guard keeps Messaging/push setup safe if launch order changes.
+        if FirebaseApp.app() == nil {
+            FirebaseApp.configure()
+        }
 
         Messaging.messaging().delegate = self
 

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -5,6 +5,8 @@
 //  Created by Марк Шавловский on 03.02.2022.
 //
 
+import FirebaseAnalytics
+import FirebaseCore
 import shared
 import SwiftUI
 
@@ -15,6 +17,17 @@ struct PapaKarloSwiftApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
     init() {
+        // Must configure Firebase before any Analytics/Messaging/Koin Firebase calls.
+        // Analytics was previously started eagerly from Koin (createdAtStart) and crashed
+        // Release builds with com.firebase.installations.
+        if FirebaseApp.app() == nil {
+            FirebaseApp.configure()
+        }
+        #if DEBUG
+        Analytics.setAnalyticsCollectionEnabled(false)
+        #else
+        Analytics.setAnalyticsCollectionEnabled(true)
+        #endif
         KoinKt.doInitKoin()
     }
     


### PR DESCRIPTION
## Summary
- Configure `FirebaseApp` and Analytics collection in `PapaKarloSwiftApp.init` **before** `doInitKoin()`, matching Crashlytics issue `d5f29e9e` on voljane 3.0.7 (321) (Kotlin fatality during `App.main` / Analytics worker).
- Remove eager iOS `FIRAnalytics.setAnalyticsCollectionEnabled` from Koin (`createdAtStart`); keep `AnalyticService` as a lazy factory.
- Guard duplicate `FirebaseApp.configure()` in `AppDelegate`.
- Fail iOS upload CI early if any publish app lacks `GoogleService-Info.plist` or BUNDLE_ID mismatches.

## Test plan
- [x] `:analytic:compileKotlinIosArm64` / `:shared:compileKotlinIosArm64` BUILD SUCCESSFUL
- [x] Release simulator build + cold start `voljane` (no crash; network after splash)
- [x] Release simulator build + cold start `djan`
- [ ] Merge to `develop` → promote to `master` to trigger Publish workflow ios (upload/submit)
- [ ] After App Store / TestFlight build is live: confirm Crashlytics issue `d5f29e9e` has no new events on the new build number
