### PR TITLE
Fix SMS OTP input reliability on iOS

### DIFF
--- a/designsystem/src/commonMain/kotlin/com/bunbeauty/designsystem/theme/Dimensions.kt
+++ b/designsystem/src/commonMain/kotlin/com/bunbeauty/designsystem/theme/Dimensions.kt
@@ -31,5 +31,6 @@ data class AppDimensions(
     val blurHeight: Dp = 16.dp,
     val smallProgressBarSize: Dp = 24.dp,
     val smsEditTextWidth: Dp = 320.dp,
+    val smsDigitHeight: Dp = 56.dp,
     val scrollScreenBottomSpace: Dp = buttonHeight + 32.dp,
 )

--- a/feature/auth/src/commonMain/kotlin/com/bunbeauty/auth/ui/SmsEditText.kt
+++ b/feature/auth/src/commonMain/kotlin/com/bunbeauty/auth/ui/SmsEditText.kt
@@ -24,12 +24,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.bunbeauty.designsystem.theme.FoodDeliveryTheme
@@ -42,45 +45,32 @@ fun SmsEditText(
     smsCodeLength: Int = 6,
     onFilled: (smsCode: String) -> Unit,
 ) {
-    var code by remember { mutableStateOf("") }
+    var textFieldValue by remember { mutableStateOf(TextFieldValue("")) }
     var isFilled by remember { mutableStateOf(false) }
+    var isFocused by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
+
+    val code = textFieldValue.text
+    val activeIndex = textFieldValue.selection.start.coerceIn(0, smsCodeLength - 1)
 
     CompositionLocalProvider(
         LocalTextSelectionColors provides FoodDeliveryTextFieldDefaults.smsCodeTextSelectionColors,
     ) {
-        Box(
-            modifier =
-                modifier.clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = { focusRequester.requestFocus() },
-                ),
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = spacedBy(8.dp),
-            ) {
-                val activeIndex = code.length.coerceAtMost(smsCodeLength - 1)
-                repeat(smsCodeLength) { index ->
-                    val digit = code.getOrNull(index)?.toString().orEmpty()
-                    SmsDigitBox(
-                        modifier = Modifier.weight(1f),
-                        digit = digit,
-                        isActive = index == activeIndex,
-                    )
-                }
-            }
-
+        Box(modifier = modifier) {
             BasicTextField(
-                value = code,
+                value = textFieldValue,
                 onValueChange = { newValue ->
                     val filtered =
-                        newValue
+                        newValue.text
                             .filter { char -> char in '0'..'9' }
                             .take(smsCodeLength)
+                    val selection =
+                        TextRange(
+                            start = newValue.selection.start.coerceIn(0, filtered.length),
+                            end = newValue.selection.end.coerceIn(0, filtered.length),
+                        )
                     val becameFilled = filtered.length == smsCodeLength && !isFilled
-                    code = filtered
+                    textFieldValue = TextFieldValue(text = filtered, selection = selection)
                     isFilled = filtered.length == smsCodeLength
                     if (becameFilled) {
                         onFilled(filtered)
@@ -89,7 +79,10 @@ fun SmsEditText(
                 modifier =
                     Modifier
                         .matchParentSize()
-                        .focusRequester(focusRequester),
+                        .focusRequester(focusRequester)
+                        .onFocusChanged { focusState ->
+                            isFocused = focusState.isFocused
+                        },
                 textStyle =
                     TextStyle(
                         color = Color.Transparent,
@@ -103,6 +96,28 @@ fun SmsEditText(
                         imeAction = ImeAction.None,
                     ),
             )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = spacedBy(8.dp),
+            ) {
+                repeat(smsCodeLength) { index ->
+                    val digit = code.getOrNull(index)?.toString().orEmpty()
+                    SmsDigitBox(
+                        modifier = Modifier.weight(1f),
+                        digit = digit,
+                        isActive = isFocused && index == activeIndex,
+                        onClick = {
+                            focusRequester.requestFocus()
+                            val cursor = index.coerceAtMost(code.length)
+                            textFieldValue =
+                                textFieldValue.copy(
+                                    selection = TextRange(cursor),
+                                )
+                        },
+                    )
+                }
+            }
         }
     }
 
@@ -115,6 +130,7 @@ fun SmsEditText(
 private fun SmsDigitBox(
     digit: String,
     isActive: Boolean,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // Visual analogue of FoodDeliveryTextFieldDefaults.smsCodeTextFieldColors
@@ -136,6 +152,11 @@ private fun SmsDigitBox(
             modifier
                 .height(FoodDeliveryTheme.dimensions.smsDigitHeight)
                 .background(FoodDeliveryTheme.colors.mainColors.surface)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onClick,
+                )
                 .drawBehind {
                     val strokeWidth = indicatorThickness.toPx()
                     val y = size.height - strokeWidth / 2

--- a/feature/auth/src/commonMain/kotlin/com/bunbeauty/auth/ui/SmsEditText.kt
+++ b/feature/auth/src/commonMain/kotlin/com/bunbeauty/auth/ui/SmsEditText.kt
@@ -1,32 +1,35 @@
 package com.bunbeauty.auth.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement.Absolute.spacedBy
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
-import androidx.compose.material3.TextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateList
-import androidx.compose.runtime.toMutableStateList
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
-import androidx.compose.ui.input.key.type
-import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.bunbeauty.designsystem.theme.FoodDeliveryTheme
@@ -39,111 +42,121 @@ fun SmsEditText(
     smsCodeLength: Int = 6,
     onFilled: (smsCode: String) -> Unit,
 ) {
-    val enteredNumbers: SnapshotStateList<String> =
-        remember {
-            (0 until smsCodeLength).map { "" }.toMutableStateList()
-        }
+    var code by remember { mutableStateOf("") }
+    var isFilled by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
 
-    val focusRequesters =
-        remember {
-            List(smsCodeLength) { FocusRequester() }
-        }
-
-    var isFilled: Boolean by remember {
-        mutableStateOf(false)
-    }
-
-    val focusManager = LocalFocusManager.current
-
-    Row(
-        modifier = modifier,
-        horizontalArrangement = spacedBy(8.dp),
+    CompositionLocalProvider(
+        LocalTextSelectionColors provides FoodDeliveryTextFieldDefaults.smsCodeTextSelectionColors,
     ) {
-        CompositionLocalProvider(
-            LocalTextSelectionColors provides FoodDeliveryTextFieldDefaults.smsCodeTextSelectionColors,
+        Box(
+            modifier =
+                modifier.clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = { focusRequester.requestFocus() },
+                ),
         ) {
-            repeat(smsCodeLength) { i ->
-                SmsDigitCell(
-                    modifier =
-                        Modifier
-                            .weight(1f)
-                            .focusRequester(focusRequesters[i]),
-                    value = enteredNumbers[i],
-                    onValueChanged = { changedValue ->
-                        enteredNumbers[i] = changedValue
-                        if (changedValue.isNotEmpty() && i < smsCodeLength - 1) {
-                            focusRequesters[i + 1].requestFocus()
-                        }
-                        if (enteredNumbers.none { enteredNumber -> enteredNumber.isBlank() } &&
-                            !isFilled
-                        ) {
-                            isFilled = true
-                            onFilled(enteredNumbers.joinToString(separator = ""))
-                        }
-                    },
-                    onFilledRemoved = {
-                        enteredNumbers[i] = ""
-                    },
-                    onEmptyRemoved = {
-                        if (i > 0) {
-                            enteredNumbers[i - 1] = ""
-                            focusRequesters[i - 1].requestFocus()
-                        }
-                    },
-                )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = spacedBy(8.dp),
+            ) {
+                val activeIndex = code.length.coerceAtMost(smsCodeLength - 1)
+                repeat(smsCodeLength) { index ->
+                    val digit = code.getOrNull(index)?.toString().orEmpty()
+                    SmsDigitBox(
+                        modifier = Modifier.weight(1f),
+                        digit = digit,
+                        isActive = index == activeIndex,
+                    )
+                }
             }
+
+            BasicTextField(
+                value = code,
+                onValueChange = { newValue ->
+                    val filtered =
+                        newValue
+                            .filter { char -> char in '0'..'9' }
+                            .take(smsCodeLength)
+                    val becameFilled = filtered.length == smsCodeLength && !isFilled
+                    code = filtered
+                    isFilled = filtered.length == smsCodeLength
+                    if (becameFilled) {
+                        onFilled(filtered)
+                    }
+                },
+                modifier =
+                    Modifier
+                        .matchParentSize()
+                        .focusRequester(focusRequester),
+                textStyle =
+                    TextStyle(
+                        color = Color.Transparent,
+                        textAlign = TextAlign.Center,
+                    ),
+                cursorBrush = SolidColor(Color.Transparent),
+                singleLine = true,
+                keyboardOptions =
+                    KeyboardOptions(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.None,
+                    ),
+            )
         }
     }
+
     LaunchedEffect(Unit) {
-        focusRequesters[0].requestFocus()
+        focusRequester.requestFocus()
     }
 }
 
 @Composable
-fun SmsDigitCell(
+private fun SmsDigitBox(
+    digit: String,
+    isActive: Boolean,
     modifier: Modifier = Modifier,
-    value: String,
-    onValueChanged: (String) -> Unit,
-    onFilledRemoved: () -> Unit,
-    onEmptyRemoved: () -> Unit,
 ) {
-    val composeCoroutineScope = rememberCoroutineScope()
+    // Visual analogue of FoodDeliveryTextFieldDefaults.smsCodeTextFieldColors
+    val indicatorColor =
+        if (isActive) {
+            FoodDeliveryTheme.colors.mainColors.primary
+        } else {
+            FoodDeliveryTheme.colors.mainColors.onSurfaceVariant
+        }
+    val indicatorThickness =
+        if (isActive) {
+            2.dp
+        } else {
+            1.dp
+        }
 
-    TextField(
+    Box(
         modifier =
             modifier
-                .onKeyEvent { event ->
-                    if (event.type == KeyEventType.KeyUp) {
-                        if (event.key == Key.Backspace) {
-                            if (value == "") {
-                                onEmptyRemoved()
-                            } else {
-                                onFilledRemoved()
-                            }
-                        }
-                    }
-                    true
+                .height(FoodDeliveryTheme.dimensions.smsDigitHeight)
+                .background(FoodDeliveryTheme.colors.mainColors.surface)
+                .drawBehind {
+                    val strokeWidth = indicatorThickness.toPx()
+                    val y = size.height - strokeWidth / 2
+                    drawLine(
+                        color = indicatorColor,
+                        start = Offset(0f, y),
+                        end = Offset(size.width, y),
+                        strokeWidth = strokeWidth,
+                    )
                 },
-        colors = FoodDeliveryTextFieldDefaults.smsCodeTextFieldColors,
-        textStyle =
-            FoodDeliveryTheme.typography
-                .bodyLarge
-                .copy(textAlign = TextAlign.Center),
-        singleLine = true,
-        value = TextFieldValue(value),
-        onValueChange = { textFieldValue ->
-            if (textFieldValue.selection.start == 1) {
-                onValueChanged(textFieldValue.text.first().toString())
-            } else {
-                onValueChanged(textFieldValue.text.last().toString())
-            }
-        },
-        keyboardOptions =
-            KeyboardOptions(
-                keyboardType = KeyboardType.Number,
-                imeAction = ImeAction.None,
-            ),
-    )
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = digit,
+            style =
+                FoodDeliveryTheme.typography.bodyLarge.copy(
+                    textAlign = TextAlign.Center,
+                ),
+            color = FoodDeliveryTheme.colors.mainColors.onSurface,
+        )
+    }
 }
 
 @Preview(showBackground = true)


### PR DESCRIPTION
## Summary
Reworked `SmsEditText` OTP input so soft keyboard backspace and paste work reliably on iOS.

- Replaced N separate `TextField`s + `onKeyEvent(Backspace)` with one hidden `BasicTextField` and visual `SmsDigitBox` cells (iOS soft keyboard often does not deliver Backspace `KeyEvent`)
- Digits-only filter (`'0'..'9'`), full-code paste support, `onFilled` latch resets when the code is shortened
- Added `smsDigitHeight = 56.dp` in `Dimensions`
- Public API of `SmsEditText` unchanged; `ConfirmRoute` not touched

## Test plan
- [ ] Open SMS confirm screen on **iOS**
- [ ] Type digits one by one — cells fill left to right
- [ ] Soft keyboard **backspace** removes the last digit correctly
- [ ] **Paste** a full 6-digit code — all cells fill and `onFilled` fires once
- [ ] After full code, delete a digit — latch resets; completing again calls `onFilled` again
- [ ] Non-digit characters are ignored
- [ ] Smoke-check on **Android** (type / backspace / paste)