### PR TITLE
Fix profile showing logged-in state after logout

### DIFF
--- a/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/di/ProfileFeatureModule.kt
+++ b/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/di/ProfileFeatureModule.kt
@@ -10,7 +10,7 @@ fun profileFeatureModule() =
     module {
         viewModel {
             ProfileViewModel(
-                userInteractor = get(),
+                observeTokenUseCase = get(),
                 getLinkListUseCase = get(),
                 buildVersion = get(buildVersionQualifier),
             )

--- a/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/presentation/profile/ProfileViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/bunbeauty/profile/presentation/profile/ProfileViewModel.kt
@@ -2,12 +2,14 @@ package com.bunbeauty.profile.presentation.profile
 
 import com.bunbeauty.core.Constants.VERSION_DIVIDER
 import com.bunbeauty.core.base.SharedStateViewModel
+import com.bunbeauty.core.domain.auth.ObserveTokenUseCase
 import com.bunbeauty.core.domain.link.GetLinkListUseCase
-import com.bunbeauty.core.domain.user.IUserInteractor
 import com.bunbeauty.core.extension.launchSafe
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
 
 class ProfileViewModel(
-    private val userInteractor: IUserInteractor,
+    private val observeTokenUseCase: ObserveTokenUseCase,
     private val getLinkListUseCase: GetLinkListUseCase,
     buildVersion: Long,
 ) : SharedStateViewModel<ProfileState.DataState, ProfileState.Action, ProfileState.Event>(
@@ -20,8 +22,11 @@ class ProfileViewModel(
                 appVersion = buildVersion.toString().toCharArray().joinToString(VERSION_DIVIDER),
             ),
     ) {
+    private var observeTokenJob: Job? = null
+
     init {
-        loadData()
+        observeToken()
+        loadLinks()
     }
 
     override fun reduce(
@@ -30,7 +35,10 @@ class ProfileViewModel(
     ) {
         when (action) {
             ProfileState.Action.BackClicked -> onBackClicked()
-            ProfileState.Action.OnRefreshClicked -> loadData()
+            ProfileState.Action.OnRefreshClicked -> {
+                observeToken()
+                loadLinks()
+            }
 
             ProfileState.Action.OnOrderHistoryClicked -> onOrderHistoryClicked()
             ProfileState.Action.OnSettingsClick -> onSettingsClicked()
@@ -44,20 +52,12 @@ class ProfileViewModel(
         }
     }
 
-    private fun loadData() {
+    private fun loadLinks() {
         sharedScope.launchSafe(
             block = {
                 val linkList = getLinkListUseCase()
                 setState {
-                    copy(
-                        state =
-                            if (userInteractor.isUserAuthorize()) {
-                                ProfileState.DataState.State.AUTHORIZED
-                            } else {
-                                ProfileState.DataState.State.UNAUTHORIZED
-                            },
-                        linkList = linkList,
-                    )
+                    copy(linkList = linkList)
                 }
             },
             onError = {
@@ -68,6 +68,34 @@ class ProfileViewModel(
                 }
             },
         )
+    }
+
+    private fun observeToken() {
+        observeTokenJob?.cancel()
+        observeTokenJob =
+            sharedScope.launchSafe(
+                block = {
+                    observeTokenUseCase().collectLatest { token ->
+                        setState {
+                            copy(
+                                state =
+                                    if (token != null) {
+                                        ProfileState.DataState.State.AUTHORIZED
+                                    } else {
+                                        ProfileState.DataState.State.UNAUTHORIZED
+                                    },
+                            )
+                        }
+                    }
+                },
+                onError = {
+                    setState {
+                        copy(
+                            state = ProfileState.DataState.State.ERROR,
+                        )
+                    }
+                },
+            )
     }
 
     private fun onBackClicked() {

--- a/shared/src/iosMain/kotlin/com/bunbeauty/shared/data/DataStoreRepository.kt
+++ b/shared/src/iosMain/kotlin/com/bunbeauty/shared/data/DataStoreRepository.kt
@@ -5,6 +5,8 @@ import com.bunbeauty.core.model.Settings
 import com.bunbeauty.core.model.UserCityUuid
 import com.bunbeauty.shared.DataStoreRepo
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import org.koin.core.component.KoinComponent
@@ -13,19 +15,23 @@ import platform.Foundation.NSUserDefaults
 actual class DataStoreRepository :
     DataStoreRepo,
     KoinComponent {
-    actual override val token: Flow<String?> =
-        flow {
-            emit(getToken())
-        }
+    private val tokenState =
+        MutableStateFlow(
+            NSUserDefaults.standardUserDefaults.stringForKey(TOKEN_KEY),
+        )
 
-    actual override suspend fun getToken(): String? = NSUserDefaults.standardUserDefaults.stringForKey(TOKEN_KEY)
+    actual override val token: Flow<String?> = tokenState.asStateFlow()
+
+    actual override suspend fun getToken(): String? = tokenState.value
 
     actual override suspend fun saveToken(token: String) {
         NSUserDefaults.standardUserDefaults.setObject(token, TOKEN_KEY)
+        tokenState.value = token
     }
 
     actual override suspend fun clearToken() {
         NSUserDefaults.standardUserDefaults.removeObjectForKey(TOKEN_KEY)
+        tokenState.value = null
     }
 
     actual override val userUuid: Flow<String?> =
@@ -202,6 +208,7 @@ actual class DataStoreRepository :
 
     actual override suspend fun clearUserData() {
         NSUserDefaults.standardUserDefaults.removeObjectForKey(TOKEN_KEY)
+        tokenState.value = null
         NSUserDefaults.standardUserDefaults.removeObjectForKey(USER_UUID_KEY)
         clearWithoutUtensils()
         removeUserSettings()

--- a/shared/src/jsMain/kotlin/com/bunbeauty/shared/data/DataStoreRepository.kt
+++ b/shared/src/jsMain/kotlin/com/bunbeauty/shared/data/DataStoreRepository.kt
@@ -5,22 +5,28 @@ import com.bunbeauty.core.model.Settings
 import com.bunbeauty.core.model.UserCityUuid
 import com.bunbeauty.shared.DataStoreRepo
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flow
 import org.koin.core.component.KoinComponent
 
 actual class DataStoreRepository :
     DataStoreRepo,
     KoinComponent {
-    actual override val token: Flow<String?> = flow { emit(getToken()) }
+    private val tokenState = MutableStateFlow(lsGet(TOKEN_KEY))
 
-    actual override suspend fun getToken(): String? = lsGet(TOKEN_KEY)
+    actual override val token: Flow<String?> = tokenState.asStateFlow()
+
+    actual override suspend fun getToken(): String? = tokenState.value
 
     actual override suspend fun saveToken(token: String) {
         lsSet(TOKEN_KEY, token)
+        tokenState.value = token
     }
 
     actual override suspend fun clearToken() {
         lsRemove(TOKEN_KEY)
+        tokenState.value = null
     }
 
     actual override val userUuid: Flow<String?> = flow { emit(getUserUuid()) }
@@ -92,6 +98,7 @@ actual class DataStoreRepository :
 
     actual override suspend fun clearUserData() {
         lsRemove(TOKEN_KEY)
+        tokenState.value = null
         lsRemove(USER_UUID_KEY)
         lsRemove(SETTINGS_USER_UUID_KEY)
         lsRemove(SETTINGS_PHONE_NUMBER_KEY)


### PR DESCRIPTION
## Summary

**Bug:** After logout from Settings the user returns (`navigateUp`) to Profile, but the screen still shows the authorized (logged-in) state.

**Cause:** `ProfileViewModel` checked `userInteractor.isUserAuthorize()` once in `init`. The ViewModel survived the return from Settings, so `AUTHORIZED` stayed cached. On iOS/JS the `token` Flow was one-shot (emit once and complete).

**Fix:**
- `ProfileViewModel`: subscribe to `ObserveTokenUseCase` (same pattern as `ProductDetailsViewModel`); `token != null` → `AUTHORIZED` / else `UNAUTHORIZED`; `observeToken` starts in `init` independently of link loading
- `ProfileFeatureModule`: wire `observeTokenUseCase` instead of `userInteractor`
- iOS/JS `DataStoreRepository`: `token` is a reactive `MutableStateFlow`, updated in `saveToken` / `clearToken` / `clearUserData`

## Test plan

- [ ] Log in → open Settings → log out of account
- [ ] On return to Profile, UI must show the unauthorized state
- [ ] Verify on **Android**
- [ ] Verify on **iOS**