### PR TITLE
Treat favorites as MenuItem like discount in the menu grid

### DIFF
--- a/core/src/commonMain/kotlin/com/bunbeauty/core/model/MenuItem.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/model/MenuItem.kt
@@ -19,4 +19,8 @@ sealed class MenuItem {
     data class Discount(
         val discount: String,
     ) : MenuItem()
+
+    data class Favorites(
+        val products: List<Product>,
+    ) : MenuItem()
 }

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuGridIndex.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuGridIndex.kt
@@ -1,11 +1,5 @@
 package com.bunbeauty.menu.presentation
 
 internal const val MENU_GRID_INDEX_LAST_ORDER = 2
-internal const val MENU_GRID_INDEX_FAVORITES = 3
 
-internal fun menuContentStartGridIndex(hasFavoritesSection: Boolean): Int =
-    if (hasFavoritesSection) {
-        MENU_GRID_INDEX_FAVORITES + 1
-    } else {
-        MENU_GRID_INDEX_FAVORITES
-    }
+internal fun menuContentStartGridIndex(): Int = MENU_GRID_INDEX_LAST_ORDER + 1

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuState.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuState.kt
@@ -13,7 +13,6 @@ interface MenuState {
         val categoryItemList: List<CategoryItem>,
         val cartCostAndCount: CartCostAndCount?,
         val menuItemList: List<MenuItem>,
-        val favoriteProductList: List<MenuItem.Product> = emptyList(),
         val state: State,
         val userScrollEnabled: Boolean,
         val lastOrder: LightOrder?,

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuViewModel.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuViewModel.kt
@@ -6,7 +6,6 @@ import com.bunbeauty.analytic.event.menu.LoadedMenuEvent
 import com.bunbeauty.analytic.parameter.MenuProductUuidEventParameter
 import com.bunbeauty.analytic.parameter.TimeParameter
 import com.bunbeauty.core.Logger
-import com.bunbeauty.core.Constants.FAVORITES_CATEGORY_UUID
 import com.bunbeauty.core.base.SharedStateViewModel
 import com.bunbeauty.core.domain.ObserveCartUseCase
 import com.bunbeauty.core.domain.auth.ObserveTokenUseCase
@@ -50,7 +49,6 @@ class MenuViewModel(
                 categoryItemList = emptyList(),
                 cartCostAndCount = null,
                 menuItemList = emptyList(),
-                favoriteProductList = emptyList(),
                 state = MenuState.DataState.State.LOADING,
                 userScrollEnabled = true,
                 lastOrder = null,
@@ -144,8 +142,7 @@ class MenuViewModel(
                     .drop(1)
                     .distinctUntilChanged()
                     .collectLatest {
-                        refreshDiscount()
-                        refreshFavoriteProducts()
+                        refreshDiscountAndFavorites()
                     }
             },
             onError = { throwable ->
@@ -154,27 +151,30 @@ class MenuViewModel(
         )
     }
 
-    private fun refreshDiscount() {
-        sharedScope.launchSafe(
-            block = {
-                val discountItem =
-                    getDiscountUseCase()?.firstOrderDiscount?.toString()?.let { discount ->
-                        MenuItem.Discount(discount = discount)
-                    }
-                setState {
-                    copy(
-                        menuItemList =
-                            listOfNotNull(discountItem) +
-                                menuItemList.filterNot { menuItem ->
-                                    menuItem is MenuItem.Discount
-                                },
-                    )
-                }
-            },
-            onError = { throwable ->
-                Logger.logE(MAIN_MENU_VIEW_MODEL_TAG, throwable.stackTraceToString())
-            },
-        )
+    private suspend fun refreshDiscountAndFavorites() {
+        val discountItem =
+            getDiscountUseCase()?.firstOrderDiscount?.toString()?.let { discount ->
+                MenuItem.Discount(discount = discount)
+            }
+        val favoritesItem = toFavoritesMenuItem(loadFavoriteProductList())
+        val menuSectionList = menuProductInteractor.getMenuSectionList()
+
+        setState {
+            copy(
+                menuItemList =
+                    buildMenuItemListPrefix(
+                        discountItem = discountItem,
+                        favoritesItem = favoritesItem,
+                    ) +
+                        menuItemList.filterNot { menuItem ->
+                            menuItem is MenuItem.Discount || menuItem is MenuItem.Favorites
+                        },
+                categoryItemList =
+                    buildCategoryItemList(
+                        menuSectionList = menuSectionList,
+                    ),
+            )
+        }
     }
 
     private fun getMenu() {
@@ -189,7 +189,7 @@ class MenuViewModel(
                 val time =
                     measureTime {
                         val menuSectionList = menuProductInteractor.getMenuSectionList()
-                        val favoriteProductList = loadFavoriteProductList()
+                        val favoritesItem = toFavoritesMenuItem(loadFavoriteProductList())
 
                         if (selectedCategoryUuid == null) {
                             selectedCategoryUuid = menuSectionList.firstOrNull()?.category?.uuid
@@ -200,16 +200,19 @@ class MenuViewModel(
                                 MenuItem.Discount(discount = discount)
                             }
                         val menuItemList =
-                            listOfNotNull(discountItem) +
+                            buildMenuItemListPrefix(
+                                discountItem = discountItem,
+                                favoritesItem = favoritesItem,
+                            ) +
                                 menuSectionList.flatMap { menuSection ->
                                     menuSection.toMenuItemList()
                                 }
                         setState {
                             copy(
-                                categoryItemList = buildCategoryItemList(
-                                    menuSectionList = menuSectionList,
-                                ),
-                                favoriteProductList = favoriteProductList,
+                                categoryItemList =
+                                    buildCategoryItemList(
+                                        menuSectionList = menuSectionList,
+                                    ),
                                 menuItemList = menuItemList,
                                 state = MenuState.DataState.State.SUCCESS,
                             )
@@ -237,14 +240,13 @@ class MenuViewModel(
         }
 
         currentMenuPosition = menuPosition
-        val hasFavoritesSection = mutableDataState.value.favoriteProductList.isNotEmpty()
 
-        if (menuPosition < menuContentStartGridIndex(hasFavoritesSection = hasFavoritesSection)) {
+        if (menuPosition < menuContentStartGridIndex()) {
             return
         }
 
         val menuListPosition =
-            (menuPosition - menuContentStartGridIndex(hasFavoritesSection = hasFavoritesSection))
+            (menuPosition - menuContentStartGridIndex())
                 .coerceAtLeast(0)
 
         sharedScope.launchSafe(
@@ -300,14 +302,24 @@ class MenuViewModel(
         }
     }
 
-    private fun findMenuProduct(uuid: String): MenuItem.Product? =
-        mutableDataState.value.favoriteProductList.find { menuProduct ->
-            menuProduct.uuid == uuid
-        } ?: mutableDataState.value.menuItemList
+    private fun findMenuProduct(uuid: String): MenuItem.Product? {
+        val menuItemList = mutableDataState.value.menuItemList
+        val favoriteProduct =
+            menuItemList
+                .filterIsInstance<MenuItem.Favorites>()
+                .flatMap { favorites -> favorites.products }
+                .find { menuProduct ->
+                    menuProduct.uuid == uuid
+                }
+        if (favoriteProduct != null) {
+            return favoriteProduct
+        }
+        return menuItemList
             .filterIsInstance<MenuItem.Product>()
             .find { menuProduct ->
                 menuProduct.uuid == uuid
             }
+    }
 
     private fun onAddProductClicked(menuProductUuid: String) {
         val menuProduct = findMenuProduct(uuid = menuProductUuid) ?: return
@@ -382,9 +394,7 @@ class MenuViewModel(
             isSelected = isCategorySelected(menuSection.category.uuid),
         )
 
-    private fun buildCategoryItemList(
-        menuSectionList: List<MenuSection>,
-    ): List<CategoryItem> =
+    private fun buildCategoryItemList(menuSectionList: List<MenuSection>): List<CategoryItem> =
         menuSectionList.map { menuSection ->
             toCategoryItemModel(menuSection)
         }
@@ -394,19 +404,36 @@ class MenuViewModel(
             menuProduct.toMenuProductItem()
         }
 
+    private fun toFavoritesMenuItem(products: List<MenuItem.Product>): MenuItem.Favorites? =
+        if (products.isNotEmpty()) {
+            MenuItem.Favorites(products = products)
+        } else {
+            null
+        }
+
+    private fun buildMenuItemListPrefix(
+        discountItem: MenuItem.Discount?,
+        favoritesItem: MenuItem.Favorites?,
+    ): List<MenuItem> = listOfNotNull(discountItem, favoritesItem)
+
     private fun refreshFavoriteProducts() {
         sharedScope.launchSafe(
             block = {
-                val favoriteProductList = loadFavoriteProductList()
+                val favoritesItem = toFavoritesMenuItem(loadFavoriteProductList())
                 val menuSectionList = menuProductInteractor.getMenuSectionList()
 
-                if (selectedCategoryUuid == FAVORITES_CATEGORY_UUID) {
-                    selectedCategoryUuid = menuSectionList.firstOrNull()?.category?.uuid
-                }
-
                 setState {
+                    val discountItem =
+                        menuItemList.filterIsInstance<MenuItem.Discount>().firstOrNull()
                     copy(
-                        favoriteProductList = favoriteProductList,
+                        menuItemList =
+                            buildMenuItemListPrefix(
+                                discountItem = discountItem,
+                                favoritesItem = favoritesItem,
+                            ) +
+                                menuItemList.filterNot { menuItem ->
+                                    menuItem is MenuItem.Discount || menuItem is MenuItem.Favorites
+                                },
                         categoryItemList =
                             buildCategoryItemList(
                                 menuSectionList = menuSectionList,

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuCategoryRow.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuCategoryRow.kt
@@ -29,7 +29,6 @@ private const val MENU_CATEGORY_ROW_INDEX = 1
 internal fun MenuCategoryRow(
     categoryItemList: ImmutableList<CategoryItem>,
     menuItemList: ImmutableList<MenuItemUi>,
-    hasFavoritesSection: Boolean,
     menuLazyGridState: LazyGridState,
     modifier: Modifier = Modifier,
     onAction: (MenuState.Action) -> Unit,
@@ -77,7 +76,6 @@ internal fun MenuCategoryRow(
                                 getMenuListPosition(
                                     categoryItem = categoryItemModel,
                                     menuItemList = menuItemList,
-                                    hasFavoritesSection = hasFavoritesSection,
                                 )
                             menuLazyGridState.alignCategoryHeaderUnderCategoryRow(
                                 headerGridIndex = index,

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuColumn.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuColumn.kt
@@ -170,7 +170,6 @@ internal fun MenuColumn(
                             .ignoreHorizontalParentPadding(horizontal = 16.dp),
                     categoryItemList = menu.categoryItemList,
                     menuItemList = menu.menuItemList,
-                    hasFavoritesSection = menu.hasFavoritesSection,
                     menuLazyGridState = menuLazyListState,
                     onAction = onAction,
                 )
@@ -206,29 +205,13 @@ internal fun MenuColumn(
                 }
             }
 
-            if (menu.hasFavoritesSection) {
-                item(
-                    key = "Favorites",
-                    span = {
-                        GridItemSpan(maxLineSpan)
-                    },
-                ) {
-                    MenuFavoritesRow(
-                        modifier = Modifier.fillMaxWidth()
-                            .ignoreHorizontalParentPadding(horizontal = 16.dp),
-                        products = menu.favoriteProductList,
-                        animatedContentScope = animatedContentScope,
-                        onAction = onAction,
-                    )
-                }
-            }
-
             itemsIndexed(
                 items = menu.menuItemList,
                 key = { _, menuItemModel -> menuItemModel.key },
                 span = { _, menuItemModel ->
                     when (menuItemModel) {
                         is MenuItemUi.Discount,
+                        is MenuItemUi.Favorites,
                         is MenuItemUi.CategoryHeader,
                         -> GridItemSpan(maxLineSpan)
 
@@ -257,6 +240,18 @@ internal fun MenuColumn(
                             modifier =
                                 Modifier
                                     .padding(top = 8.dp),
+                        )
+                    }
+
+                    is MenuItemUi.Favorites -> {
+                        MenuFavoritesRow(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .ignoreHorizontalParentPadding(horizontal = 16.dp),
+                            products = menuItem.products,
+                            animatedContentScope = animatedContentScope,
+                            onAction = onAction,
                         )
                     }
 

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuFavoritesRow.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuFavoritesRow.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
@@ -42,7 +42,7 @@ internal fun MenuFavoritesRow(
                 Modifier.padding(
                     top = 16.dp,
                     start = 16.dp,
-                    end = 16.dp
+                    end = 16.dp,
                 ),
             text = stringResource(resource = Res.string.title_favorites),
             style = FoodDeliveryTheme.typography.titleMedium.bold,

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuScreen.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuScreen.kt
@@ -173,8 +173,6 @@ private fun MenuScreenSuccessPreview() {
                                 getCategoryItem("5"),
                                 getCategoryItem("6"),
                             ),
-                        favoriteProductList = persistentListOf(),
-                        hasFavoritesSection = false,
                         menuItemList =
                             persistentListOf(
                                 getMenuCategoryHeaderItem("4"),
@@ -224,8 +222,6 @@ private fun MenuScreenLoadingPreview() {
                 viewState =
                     MenuViewState(
                         categoryItemList = persistentListOf(),
-                        favoriteProductList = persistentListOf(),
-                        hasFavoritesSection = false,
                         topCartUi =
                             TopCartUi(
                                 cost = "100",
@@ -253,8 +249,6 @@ private fun MenuScreenErrorPreview() {
                 viewState =
                     MenuViewState(
                         categoryItemList = persistentListOf(),
-                        favoriteProductList = persistentListOf(),
-                        hasFavoritesSection = false,
                         topCartUi =
                             TopCartUi(
                                 cost = "100",

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/mapper/MenuStateMapper.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/mapper/MenuStateMapper.kt
@@ -11,16 +11,8 @@ import com.bunbeauty.menu.ui.state.MenuItemUi
 import com.bunbeauty.menu.ui.state.MenuViewState
 import kotlinx.collections.immutable.toImmutableList
 
-fun MenuState.DataState.mapState(): MenuViewState {
-    val favoriteProducts =
-        favoriteProductList
-            .map { menuProduct ->
-                menuProduct.toMenuProductItemUi()
-            }.map { menuItemUi ->
-                menuItemUi.product
-            }.toImmutableList()
-
-    return MenuViewState(
+fun MenuState.DataState.mapState(): MenuViewState =
+    MenuViewState(
         topCartUi =
             TopCartUi(
                 cost =
@@ -35,8 +27,6 @@ fun MenuState.DataState.mapState(): MenuViewState {
                 .map { menuItem ->
                     menuItem.toMenuItemUi()
                 }.toImmutableList(),
-        favoriteProductList = favoriteProducts,
-        hasFavoritesSection = favoriteProducts.isNotEmpty(),
         state =
             when (state) {
                 MenuState.DataState.State.LOADING -> MenuViewState.State.Loading
@@ -47,18 +37,16 @@ fun MenuState.DataState.mapState(): MenuViewState {
         lastOrder = lastOrder,
         scrollToTopRequest = scrollToTopRequest,
     )
-}
 
 fun getMenuListPosition(
     categoryItem: CategoryItem,
     menuItemList: List<MenuItemUi>,
-    hasFavoritesSection: Boolean,
 ): Int {
     val indexInMenuList =
         menuItemList.indexOfFirst { menuItem ->
             (menuItem as? MenuItemUi.CategoryHeader)?.uuid == categoryItem.uuid
         }
-    val startIndex = menuContentStartGridIndex(hasFavoritesSection = hasFavoritesSection)
+    val startIndex = menuContentStartGridIndex()
     return if (indexInMenuList < 0) {
         startIndex
     } else {
@@ -100,6 +88,17 @@ private fun MenuItem.toMenuItemUi(): MenuItemUi =
             MenuItemUi.Discount(
                 key = "Discount",
                 discount = discount,
+            )
+        }
+
+        is MenuItem.Favorites -> {
+            MenuItemUi.Favorites(
+                key = "Favorites",
+                products =
+                    products
+                        .map { product ->
+                            product.toMenuProductItemUi().product
+                        }.toImmutableList(),
             )
         }
     }

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/state/MenuViewState.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/state/MenuViewState.kt
@@ -13,8 +13,6 @@ data class MenuViewState(
     val categoryItemList: ImmutableList<CategoryItem>,
     val topCartUi: TopCartUi,
     val menuItemList: ImmutableList<MenuItemUi>,
-    val favoriteProductList: ImmutableList<ProductUi>,
-    val hasFavoritesSection: Boolean,
     val state: State,
     val userScrollEnabled: Boolean,
     val lastOrder: LightOrder?,
@@ -51,5 +49,11 @@ sealed interface MenuItemUi {
     data class Discount(
         override val key: String,
         val discount: String,
+    ) : MenuItemUi
+
+    @Immutable
+    data class Favorites(
+        override val key: String,
+        val products: ImmutableList<ProductUi>,
     ) : MenuItemUi
 }

--- a/iosApp/iosApp/Version.xcconfig
+++ b/iosApp/iosApp/Version.xcconfig
@@ -8,3 +8,4 @@
 
 APP_VERSION = 3.1.2
 APP_BUILD = 312
+


### PR DESCRIPTION
## Summary
- Model favorites as `MenuItem.Favorites` / `MenuItemUi.Favorites`, same pattern as Discount, instead of a separate LazyGrid section and parallel `favoriteProductList` state.
- Render Favorites in the shared `itemsIndexed(menuItemList)` path so on-screen order is **Discount → Favorites → categories/products**.
- Refresh discount and favorites atomically on token change to avoid racing `setState` rewrites of `menuItemList`.

## Test plan
- [x] Open menu with no favorites — no favorites row; discount (if any) still shows above categories
- [ ] Open menu with favorites and discount — discount banner first, then favorites row, then categories
- [ ] Open menu with favorites only — favorites appear above categories
- [ ] Tap a favorite product — opens product details / add-to-cart works
- [ ] Add/remove a favorite and return to menu (`RefreshFavorites`) — row updates correctly
- [ ] Log in / token change while on menu — discount and favorites stay consistent (no flicker/missing section)
- [ ] Category chip scroll still aligns headers correctly with and without favorites