### PR TITLE
Add client personal discount via settings first-order path

### DIFF
--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/discount/GetDiscountUseCaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/discount/GetDiscountUseCaseImpl.kt
@@ -4,6 +4,7 @@ import com.bunbeauty.core.domain.repo.DiscountRepo
 import com.bunbeauty.core.domain.repo.OrderRepo
 import com.bunbeauty.core.domain.repo.SettingsRepo
 import com.bunbeauty.core.model.Discount
+import com.bunbeauty.core.model.DiscountSource
 
 interface GetDiscountUseCase {
     suspend operator fun invoke(): Discount?
@@ -17,12 +18,15 @@ class GetDiscountUseCaseImpl(
     override suspend operator fun invoke(): Discount? {
         val personalDiscountPercent = settingsRepo.getSettings()?.personalDiscountPercent
         if (personalDiscountPercent != null) {
-            return Discount(firstOrderDiscount = personalDiscountPercent)
+            return Discount(
+                firstOrderDiscount = personalDiscountPercent,
+                source = DiscountSource.PERSONAL,
+            )
         }
 
         val lastOrder = orderRepository.getLastOrderByUserUuidLocalFirst()
         return if (lastOrder == null) {
-            discountRepository.getDiscount()
+            discountRepository.getDiscount()?.copy(source = DiscountSource.FIRST_ORDER)
         } else {
             null
         }

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/discount/GetDiscountUseCaseImpl.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/discount/GetDiscountUseCaseImpl.kt
@@ -2,6 +2,7 @@ package com.bunbeauty.core.domain.discount
 
 import com.bunbeauty.core.domain.repo.DiscountRepo
 import com.bunbeauty.core.domain.repo.OrderRepo
+import com.bunbeauty.core.domain.repo.SettingsRepo
 import com.bunbeauty.core.model.Discount
 
 interface GetDiscountUseCase {
@@ -11,11 +12,15 @@ interface GetDiscountUseCase {
 class GetDiscountUseCaseImpl(
     private val discountRepository: DiscountRepo,
     private val orderRepository: OrderRepo,
+    private val settingsRepo: SettingsRepo,
 ) : GetDiscountUseCase {
     override suspend operator fun invoke(): Discount? {
+        val personalDiscountPercent = settingsRepo.getSettings()?.personalDiscountPercent
+        if (personalDiscountPercent != null) {
+            return Discount(firstOrderDiscount = personalDiscountPercent)
+        }
+
         val lastOrder = orderRepository.getLastOrderByUserUuidLocalFirst()
-
-
         return if (lastOrder == null) {
             discountRepository.getDiscount()
         } else {

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/order/CreateOrderUseCase.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/order/CreateOrderUseCase.kt
@@ -1,5 +1,9 @@
 package com.bunbeauty.core.domain.order
 
+import com.bunbeauty.core.domain.repo.CartProductRepo
+import com.bunbeauty.core.domain.repo.OrderRepo
+import com.bunbeauty.core.domain.repo.SettingsRepo
+import com.bunbeauty.core.domain.util.DateTimeUtil
 import com.bunbeauty.core.model.address.UserAddress
 import com.bunbeauty.core.model.cafe.Cafe
 import com.bunbeauty.core.model.cart.CartProduct
@@ -8,15 +12,13 @@ import com.bunbeauty.core.model.order.CreatedOrder
 import com.bunbeauty.core.model.order.CreatedOrderAddress
 import com.bunbeauty.core.model.order.OrderCode
 import com.bunbeauty.core.model.product.CreatedOrderProduct
-import com.bunbeauty.core.domain.repo.CartProductRepo
-import com.bunbeauty.core.domain.repo.OrderRepo
-import com.bunbeauty.core.domain.util.DateTimeUtil
 import kotlin.time.ExperimentalTime
 
 class CreateOrderUseCase(
     private val cartProductRepo: CartProductRepo,
     private val dateTimeUtil: DateTimeUtil,
     private val orderRepo: OrderRepo,
+    private val settingsRepo: SettingsRepo,
 ) {
     @OptIn(ExperimentalTime::class)
     suspend operator fun invoke(
@@ -72,7 +74,11 @@ class CreateOrderUseCase(
                 paymentMethod = paymentMethod,
             )
 
-        return orderRepo.createOrder(createdOrder = createdOrder)
+        val orderCode = orderRepo.createOrder(createdOrder = createdOrder)
+        if (orderCode != null) {
+            settingsRepo.refreshSettings()
+        }
+        return orderCode
     }
 
     private fun getSortedAdditionUuidList(cartProduct: CartProduct) =

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/repo/SettingsRepo.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/repo/SettingsRepo.kt
@@ -1,11 +1,15 @@
 package com.bunbeauty.core.domain.repo
 
 import com.bunbeauty.core.model.Settings
-import com.bunbeauty.core.model.city.City
 import kotlinx.coroutines.flow.Flow
 
 interface SettingsRepo {
     suspend fun observeSettings(): Flow<Settings?>
+
+    suspend fun getSettings(): Settings?
+
+    suspend fun refreshSettings(): Settings?
+
     suspend fun updateEmail(
         email: String,
     ): Settings?

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/domain/settings/RefreshSettingsUseCase.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/domain/settings/RefreshSettingsUseCase.kt
@@ -1,0 +1,10 @@
+package com.bunbeauty.core.domain.settings
+
+import com.bunbeauty.core.domain.repo.SettingsRepo
+import com.bunbeauty.core.model.Settings
+
+class RefreshSettingsUseCase(
+    private val settingsRepo: SettingsRepo,
+) {
+    suspend operator fun invoke(): Settings? = settingsRepo.refreshSettings()
+}

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/model/Discount.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/model/Discount.kt
@@ -1,5 +1,11 @@
 package com.bunbeauty.core.model
 
+enum class DiscountSource {
+    FIRST_ORDER,
+    PERSONAL,
+}
+
 data class Discount(
     val firstOrderDiscount: Int?,
+    val source: DiscountSource = DiscountSource.FIRST_ORDER,
 )

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/model/MenuItem.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/model/MenuItem.kt
@@ -18,6 +18,7 @@ sealed class MenuItem {
 
     data class Discount(
         val discount: String,
+        val source: DiscountSource,
     ) : MenuItem()
 
     data class Favorites(

--- a/core/src/commonMain/kotlin/com/bunbeauty/core/model/Settings.kt
+++ b/core/src/commonMain/kotlin/com/bunbeauty/core/model/Settings.kt
@@ -4,4 +4,5 @@ class Settings(
     val userUuid: String,
     val phoneNumber: String,
     val email: String?,
+    val personalDiscountPercent: Int? = null,
 )

--- a/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="error_menu_loading">Не удалось загрузить меню</string>
     <string name="title_menu_discount">Скидка %1$s%</string>
     <string name="msg_menu_discount">Успей сделать первый заказ со скидкой %1$s%</string>
+    <string name="msg_menu_personal_discount">Ваша скидка на следующий заказ %1$s%</string>
     <string name="msg_menu_product_added">Добавлено</string>
     <string name="msg_menu_product_edited">Изменено</string>
     <string name="title_menu_last_order">Ваш заказ</string>

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/di/MenuFeatureModule.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/di/MenuFeatureModule.kt
@@ -12,6 +12,7 @@ fun menuFeatureModule() =
                 observeCartUseCase = get(),
                 addMenuProductUseCase = get(),
                 getDiscountUseCase = get(),
+                refreshSettingsUseCase = get(),
                 analyticService = get(),
                 observeLastOrderUseCase = get(),
                 stopObserveOrdersUseCase = get(),

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuState.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuState.kt
@@ -60,7 +60,7 @@ interface MenuState {
 
         data object StopLastOrderObservation : Action
 
-        data object RefreshFavorites : Action
+        data object RefreshDiscountAndFavorites : Action
 
         data object ScrollToTop : Action
     }

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuViewModel.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuViewModel.kt
@@ -101,7 +101,7 @@ class MenuViewModel(
             MenuState.Action.OnCartClicked -> onCartClicked()
             MenuState.Action.StartLastOrderObservation -> startLastOrderObservation()
             MenuState.Action.StopLastOrderObservation -> stopLastOrderObservation()
-            MenuState.Action.RefreshFavorites -> refreshFavoriteProducts()
+            MenuState.Action.RefreshDiscountAndFavorites -> refreshDiscountAndFavoritesOnStart()
             MenuState.Action.ScrollToTop -> scrollToTop()
         }
     }
@@ -427,30 +427,10 @@ class MenuViewModel(
         favoritesItem: MenuItem.Favorites?,
     ): List<MenuItem> = listOfNotNull(discountItem, favoritesItem)
 
-    private fun refreshFavoriteProducts() {
+    private fun refreshDiscountAndFavoritesOnStart() {
         sharedScope.launchSafe(
             block = {
-                val favoritesItem = toFavoritesMenuItem(loadFavoriteProductList())
-                val menuSectionList = menuProductInteractor.getMenuSectionList()
-
-                setState {
-                    val discountItem =
-                        menuItemList.filterIsInstance<MenuItem.Discount>().firstOrNull()
-                    copy(
-                        menuItemList =
-                            buildMenuItemListPrefix(
-                                discountItem = discountItem,
-                                favoritesItem = favoritesItem,
-                            ) +
-                                menuItemList.filterNot { menuItem ->
-                                    menuItem is MenuItem.Discount || menuItem is MenuItem.Favorites
-                                },
-                        categoryItemList =
-                            buildCategoryItemList(
-                                menuSectionList = menuSectionList,
-                            ),
-                    )
-                }
+                refreshDiscountAndFavorites()
             },
             onError = { throwable ->
                 Logger.logE(MAIN_MENU_VIEW_MODEL_TAG, throwable.stackTraceToString())

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuViewModel.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuViewModel.kt
@@ -19,6 +19,7 @@ import com.bunbeauty.core.domain.order.StopObserveOrdersUseCase
 import com.bunbeauty.core.domain.settings.RefreshSettingsUseCase
 import com.bunbeauty.core.extension.launchSafe
 import com.bunbeauty.core.model.CategoryItem
+import com.bunbeauty.core.model.Discount
 import com.bunbeauty.core.model.MenuItem
 import com.bunbeauty.core.model.mapper.toMenuItemList
 import com.bunbeauty.core.model.mapper.toMenuProductItem
@@ -32,6 +33,15 @@ import kotlinx.coroutines.launch
 import kotlin.time.measureTime
 
 private const val MAIN_MENU_VIEW_MODEL_TAG = "MenuViewModel"
+
+private fun Discount?.toMenuDiscountItem(): MenuItem.Discount? {
+    val discount = this ?: return null
+    val percent = discount.firstOrderDiscount ?: return null
+    return MenuItem.Discount(
+        discount = percent.toString(),
+        source = discount.source,
+    )
+}
 
 class MenuViewModel(
     private val menuProductInteractor: IMenuProductInteractor,
@@ -155,10 +165,7 @@ class MenuViewModel(
 
     private suspend fun refreshDiscountAndFavorites() {
         refreshSettingsUseCase()
-        val discountItem =
-            getDiscountUseCase()?.firstOrderDiscount?.toString()?.let { discount ->
-                MenuItem.Discount(discount = discount)
-            }
+        val discountItem = getDiscountUseCase().toMenuDiscountItem()
         val favoritesItem = toFavoritesMenuItem(loadFavoriteProductList())
         val menuSectionList = menuProductInteractor.getMenuSectionList()
 
@@ -201,9 +208,7 @@ class MenuViewModel(
                         val discountItem =
                             run {
                                 refreshSettingsUseCase()
-                                getDiscountUseCase()?.firstOrderDiscount?.toString()?.let { discount ->
-                                    MenuItem.Discount(discount = discount)
-                                }
+                                getDiscountUseCase().toMenuDiscountItem()
                             }
                         val menuItemList =
                             buildMenuItemListPrefix(

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuViewModel.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/presentation/MenuViewModel.kt
@@ -16,6 +16,7 @@ import com.bunbeauty.core.domain.menu_product.IMenuProductInteractor
 import com.bunbeauty.core.domain.order.GetLastOrderUseCase
 import com.bunbeauty.core.domain.order.ObserveLastOrderUseCase
 import com.bunbeauty.core.domain.order.StopObserveOrdersUseCase
+import com.bunbeauty.core.domain.settings.RefreshSettingsUseCase
 import com.bunbeauty.core.extension.launchSafe
 import com.bunbeauty.core.model.CategoryItem
 import com.bunbeauty.core.model.MenuItem
@@ -37,6 +38,7 @@ class MenuViewModel(
     private val observeCartUseCase: ObserveCartUseCase,
     private val addMenuProductUseCase: AddMenuProductUseCase,
     private val getDiscountUseCase: GetDiscountUseCase,
+    private val refreshSettingsUseCase: RefreshSettingsUseCase,
     private val analyticService: AnalyticService,
     private val observeLastOrderUseCase: ObserveLastOrderUseCase,
     private val stopObserveOrdersUseCase: StopObserveOrdersUseCase,
@@ -152,6 +154,7 @@ class MenuViewModel(
     }
 
     private suspend fun refreshDiscountAndFavorites() {
+        refreshSettingsUseCase()
         val discountItem =
             getDiscountUseCase()?.firstOrderDiscount?.toString()?.let { discount ->
                 MenuItem.Discount(discount = discount)
@@ -196,8 +199,11 @@ class MenuViewModel(
                         }
 
                         val discountItem =
-                            getDiscountUseCase()?.firstOrderDiscount?.toString()?.let { discount ->
-                                MenuItem.Discount(discount = discount)
+                            run {
+                                refreshSettingsUseCase()
+                                getDiscountUseCase()?.firstOrderDiscount?.toString()?.let { discount ->
+                                    MenuItem.Discount(discount = discount)
+                                }
                             }
                         val menuItemList =
                             buildMenuItemListPrefix(

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuColumn.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuColumn.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.bunbeauty.core.model.DiscountSource
 import com.bunbeauty.designsystem.theme.FoodDeliveryTheme
 import com.bunbeauty.designsystem.theme.bold
 import com.bunbeauty.designsystem.theme.logoMedium
@@ -55,6 +56,7 @@ import papakarlo.designsystem.generated.resources.description_login_logo
 import papakarlo.designsystem.generated.resources.ic_discount
 import papakarlo.designsystem.generated.resources.ic_profile
 import papakarlo.designsystem.generated.resources.msg_menu_discount
+import papakarlo.designsystem.generated.resources.msg_menu_personal_discount
 import papakarlo.designsystem.generated.resources.title_menu
 import papakarlo.designsystem.generated.resources.title_menu_discount
 
@@ -221,17 +223,25 @@ internal fun MenuColumn(
             ) { _, menuItem ->
                 when (menuItem) {
                     is MenuItemUi.Discount -> {
+                        val discountMessage =
+                            if (menuItem.source == DiscountSource.PERSONAL) {
+                                stringResource(
+                                    resource = Res.string.msg_menu_personal_discount,
+                                    menuItem.discount,
+                                )
+                            } else {
+                                stringResource(
+                                    resource = Res.string.msg_menu_discount,
+                                    menuItem.discount,
+                                )
+                            }
                         BannerCard(
                             title =
                                 stringResource(
                                     resource = Res.string.title_menu_discount,
                                     menuItem.discount,
                                 ),
-                            text =
-                                stringResource(
-                                    resource = Res.string.msg_menu_discount,
-                                    menuItem.discount,
-                                ),
+                            text = discountMessage,
                             icon = Res.drawable.ic_discount,
                             iconDescription =
                                 stringResource(

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuRoute.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/MenuRoute.kt
@@ -55,7 +55,7 @@ fun MenuRoute(
 
     LifecycleStartEffect(Unit) {
         onAction(MenuState.Action.StartLastOrderObservation)
-        onAction(MenuState.Action.RefreshFavorites)
+        onAction(MenuState.Action.RefreshDiscountAndFavorites)
         onStopOrDispose {
             onAction(MenuState.Action.StopLastOrderObservation)
         }

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/mapper/MenuStateMapper.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/mapper/MenuStateMapper.kt
@@ -88,6 +88,7 @@ private fun MenuItem.toMenuItemUi(): MenuItemUi =
             MenuItemUi.Discount(
                 key = "Discount",
                 discount = discount,
+                source = source,
             )
         }
 

--- a/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/state/MenuViewState.kt
+++ b/feature/menu/src/commonMain/kotlin/com/bunbeauty/menu/ui/state/MenuViewState.kt
@@ -3,6 +3,7 @@ package com.bunbeauty.menu.ui.state
 import androidx.compose.runtime.Immutable
 import com.bunbeauty.core.base.BaseViewState
 import com.bunbeauty.core.model.CategoryItem
+import com.bunbeauty.core.model.DiscountSource
 import com.bunbeauty.core.model.ProductUi
 import com.bunbeauty.core.model.order.LightOrder
 import com.bunbeauty.designsystem.ui.element.TopCartUi
@@ -49,6 +50,7 @@ sealed interface MenuItemUi {
     data class Discount(
         override val key: String,
         val discount: String,
+        val source: DiscountSource,
     ) : MenuItemUi
 
     @Immutable

--- a/shared/src/androidMain/kotlin/com/bunbeauty/shared/data/DataStoreRepository.kt
+++ b/shared/src/androidMain/kotlin/com/bunbeauty/shared/data/DataStoreRepository.kt
@@ -87,6 +87,8 @@ actual class DataStoreRepository :
                         userUuid = userUuid,
                         phoneNumber = phoneNumber,
                         email = settingsDataStore[SETTINGS_EMAIL_KEY],
+                        personalDiscountPercent =
+                            settingsDataStore[SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY],
                     )
                 }
             }
@@ -99,6 +101,12 @@ actual class DataStoreRepository :
             settingsDataStore[SETTINGS_USER_UUID_KEY] = settings.userUuid
             settingsDataStore[SETTINGS_PHONE_NUMBER_KEY] = settings.phoneNumber
             settingsDataStore[SETTINGS_EMAIL_KEY] = settings.email.orEmpty()
+            val personalDiscountPercent = settings.personalDiscountPercent
+            if (personalDiscountPercent != null) {
+                settingsDataStore[SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY] = personalDiscountPercent
+            } else {
+                settingsDataStore.remove(SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY)
+            }
         }
     }
 
@@ -256,9 +264,12 @@ actual class DataStoreRepository :
         private const val SETTINGS_USER_UUID = "settings user uuid"
         private const val SETTINGS_PHONE_NUMBER = "settings phone number"
         private const val SETTINGS_EMAIL = "settings email"
+        private const val SETTINGS_PERSONAL_DISCOUNT_PERCENT = "settings personal discount percent"
         private val SETTINGS_USER_UUID_KEY = stringPreferencesKey(SETTINGS_USER_UUID)
         private val SETTINGS_PHONE_NUMBER_KEY = stringPreferencesKey(SETTINGS_PHONE_NUMBER)
         private val SETTINGS_EMAIL_KEY = stringPreferencesKey(SETTINGS_EMAIL)
+        private val SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY =
+            intPreferencesKey(SETTINGS_PERSONAL_DISCOUNT_PERCENT)
 
         private const val USER_UUID_DATA_STORE = "user id data store"
         private const val USER_UUID = "user uuid"

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/mapper/SettingsMapper.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/mapper/SettingsMapper.kt
@@ -9,5 +9,6 @@ class SettingsMapper {
             userUuid = settingsServer.userUuid,
             phoneNumber = settingsServer.phoneNumber,
             email = settingsServer.email,
+            personalDiscountPercent = settingsServer.personalDiscountPercent,
         )
 }

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/network/model/SettingsServer.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/network/model/SettingsServer.kt
@@ -11,4 +11,6 @@ data class SettingsServer(
     val phoneNumber: String,
     @SerialName("email")
     val email: String?,
+    @SerialName("personalDiscountPercent")
+    val personalDiscountPercent: Int? = null,
 )

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/repository/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/repository/SettingsRepository.kt
@@ -26,6 +26,28 @@ class SettingsRepository(
         return dataStoreRepo.settings
     }
 
+    override suspend fun getSettings(): Settings? {
+        val localSettings = dataStoreRepo.getSettings()
+        if (localSettings != null && localSettings.userUuid.isNotEmpty()) {
+            return localSettings
+        }
+        return refreshSettings()
+    }
+
+    override suspend fun refreshSettings(): Settings? {
+        val token = dataStoreRepo.getToken() ?: return dataStoreRepo.getSettings()
+        return networkConnector.getSettings(token).getNullableResult(
+            onError = {
+                dataStoreRepo.getSettings()
+            },
+            onSuccess = { settingsServer ->
+                val settings = settingsMapper.toSettings(settingsServer)
+                dataStoreRepo.saveSettings(settings)
+                settings
+            },
+        )
+    }
+
     override suspend fun updateEmail(email: String): Settings? {
         val token = dataStoreRepo.getToken() ?: return null
         return networkConnector

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/usecase/OrderUseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/usecase/OrderUseCaseModule.kt
@@ -21,6 +21,7 @@ internal fun orderUseCaseModule() =
                 cartProductRepo = get(),
                 dateTimeUtil = get(),
                 orderRepo = get(),
+                settingsRepo = get(),
             )
         }
         factory<TakeInProgressLightOrderUseCase> {

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/usecase/UseCaseModule.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/di/usecase/UseCaseModule.kt
@@ -20,6 +20,7 @@ import com.bunbeauty.core.domain.menu_product.GetMenuProductListUseCase
 import com.bunbeauty.core.domain.menu_product.GetMenuProductListUseCaseImpl
 import com.bunbeauty.core.domain.menu_product.GetMenuProductUseCase
 import com.bunbeauty.core.domain.settings.ObserveSettingsUseCase
+import com.bunbeauty.core.domain.settings.RefreshSettingsUseCase
 import com.bunbeauty.core.domain.settings.UpdateEmailUseCase
 import com.bunbeauty.core.domain.splash.CheckOneCityUseCase
 import com.bunbeauty.core.domain.splash.CheckUpdateUseCase
@@ -64,6 +65,11 @@ internal fun useCaseModules() =
             )
         }
         factory {
+            RefreshSettingsUseCase(
+                settingsRepo = get(),
+            )
+        }
+        factory {
             UpdateEmailUseCase(
                 settingsRepository = get(),
             )
@@ -104,6 +110,7 @@ internal fun useCaseModules() =
             GetDiscountUseCaseImpl(
                 discountRepository = get(),
                 orderRepository = get(),
+                settingsRepo = get(),
             )
         }
         factory {

--- a/shared/src/commonTest/kotlin/com/bunbeauty/domain/feature/discount/GetDiscountUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/bunbeauty/domain/feature/discount/GetDiscountUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.bunbeauty.core.domain.repo.DiscountRepo
 import com.bunbeauty.core.domain.repo.OrderRepo
 import com.bunbeauty.core.domain.repo.SettingsRepo
 import com.bunbeauty.core.model.Discount
+import com.bunbeauty.core.model.DiscountSource
 import com.bunbeauty.core.model.Settings
 import com.bunbeauty.core.model.date_time.Date
 import com.bunbeauty.core.model.date_time.DateTime
@@ -43,6 +44,10 @@ class GetDiscountUseCaseTest {
                 expected = 10,
                 actual = discount?.firstOrderDiscount,
             )
+            assertEquals(
+                expected = DiscountSource.FIRST_ORDER,
+                actual = discount?.source,
+            )
         }
 
     @Test
@@ -57,6 +62,10 @@ class GetDiscountUseCaseTest {
             assertEquals(
                 expected = 10,
                 actual = discount?.firstOrderDiscount,
+            )
+            assertEquals(
+                expected = DiscountSource.FIRST_ORDER,
+                actual = discount?.source,
             )
         }
 
@@ -74,6 +83,10 @@ class GetDiscountUseCaseTest {
             assertEquals(
                 expected = 10,
                 actual = discount?.firstOrderDiscount,
+            )
+            assertEquals(
+                expected = DiscountSource.FIRST_ORDER,
+                actual = discount?.source,
             )
         }
 
@@ -109,6 +122,10 @@ class GetDiscountUseCaseTest {
                 expected = 15,
                 actual = discount?.firstOrderDiscount,
             )
+            assertEquals(
+                expected = DiscountSource.PERSONAL,
+                actual = discount?.source,
+            )
         }
 
     @Test
@@ -126,6 +143,10 @@ class GetDiscountUseCaseTest {
                 expected = 15,
                 actual = discount?.firstOrderDiscount,
             )
+            assertEquals(
+                expected = DiscountSource.PERSONAL,
+                actual = discount?.source,
+            )
         }
 
     @Test
@@ -142,6 +163,10 @@ class GetDiscountUseCaseTest {
             assertEquals(
                 expected = 10,
                 actual = discount?.firstOrderDiscount,
+            )
+            assertEquals(
+                expected = DiscountSource.FIRST_ORDER,
+                actual = discount?.source,
             )
         }
 

--- a/shared/src/commonTest/kotlin/com/bunbeauty/domain/feature/discount/GetDiscountUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/bunbeauty/domain/feature/discount/GetDiscountUseCaseTest.kt
@@ -4,7 +4,9 @@ import com.bunbeauty.core.domain.discount.GetDiscountUseCase
 import com.bunbeauty.core.domain.discount.GetDiscountUseCaseImpl
 import com.bunbeauty.core.domain.repo.DiscountRepo
 import com.bunbeauty.core.domain.repo.OrderRepo
+import com.bunbeauty.core.domain.repo.SettingsRepo
 import com.bunbeauty.core.model.Discount
+import com.bunbeauty.core.model.Settings
 import com.bunbeauty.core.model.date_time.Date
 import com.bunbeauty.core.model.date_time.DateTime
 import com.bunbeauty.core.model.date_time.Time
@@ -20,24 +22,23 @@ import kotlin.test.assertEquals
 class GetDiscountUseCaseTest {
     private val discountRepository: DiscountRepo = mock()
     private val orderRepository: OrderRepo = mock()
+    private val settingsRepo: SettingsRepo = mock()
     private val getDiscountUseCase: GetDiscountUseCase =
         GetDiscountUseCaseImpl(
             discountRepository = discountRepository,
             orderRepository = orderRepository,
+            settingsRepo = settingsRepo,
         )
 
     @Test
     fun `should return firstDiscount 10 when token is null`() =
         runTest {
-            // Given
-
+            everySuspend { settingsRepo.getSettings() } returns null
             everySuspend { discountRepository.getDiscount() } returns Discount(10)
             everySuspend { orderRepository.getLastOrderByUserUuidLocalFirst() } returns null
 
-            // When
             val discount = getDiscountUseCase()
 
-            // Then
             assertEquals(
                 expected = 10,
                 actual = discount?.firstOrderDiscount,
@@ -47,15 +48,12 @@ class GetDiscountUseCaseTest {
     @Test
     fun `should return firstDiscount 10 when userUuid is null`() =
         runTest {
-            // Given
-
+            everySuspend { settingsRepo.getSettings() } returns null
             everySuspend { discountRepository.getDiscount() } returns Discount(10)
             everySuspend { orderRepository.getLastOrderByUserUuidLocalFirst() } returns null
 
-            // When
             val discount = getDiscountUseCase()
 
-            // Then
             assertEquals(
                 expected = 10,
                 actual = discount?.firstOrderDiscount,
@@ -65,18 +63,14 @@ class GetDiscountUseCaseTest {
     @Test
     fun `should return firstDiscount 10 when lastOrder is null`() =
         runTest {
-            // Given
-
+            everySuspend { settingsRepo.getSettings() } returns null
             everySuspend {
                 orderRepository.getLastOrderByUserUuidLocalFirst()
             } returns null
-
             everySuspend { discountRepository.getDiscount() } returns Discount(10)
 
-            // When
             val discount = getDiscountUseCase()
 
-            // Then
             assertEquals(
                 expected = 10,
                 actual = discount?.firstOrderDiscount,
@@ -86,35 +80,110 @@ class GetDiscountUseCaseTest {
     @Test
     fun `should return null when lastOrder is not empty`() =
         runTest {
-            // Given
+            everySuspend { settingsRepo.getSettings() } returns null
             everySuspend {
                 orderRepository.getLastOrderByUserUuidLocalFirst()
-            } returns
-                LightOrder(
-                    uuid = "uuid",
-                    status = OrderStatus.DONE,
-                    code = "code",
-                    dateTime =
-                        DateTime(
-                            date =
-                                Date(
-                                    dayOfMonth = 5474,
-                                    monthNumber = 7337,
-                                    year = 1992,
-                                ),
-                            time = Time(hours = 3796, minutes = 8009),
-                        ),
-                )
-
+            } returns lightOrder()
             everySuspend { discountRepository.getDiscount() } returns Discount(10)
 
-            // When
             val discount = getDiscountUseCase()
 
-            // Then
             assertEquals(
                 expected = null,
                 actual = discount,
             )
         }
+
+    @Test
+    fun `should return personal discount when personalDiscountPercent is set and lastOrder exists`() =
+        runTest {
+            everySuspend { settingsRepo.getSettings() } returns settings(personalDiscountPercent = 15)
+            everySuspend {
+                orderRepository.getLastOrderByUserUuidLocalFirst()
+            } returns lightOrder()
+            everySuspend { discountRepository.getDiscount() } returns Discount(10)
+
+            val discount = getDiscountUseCase()
+
+            assertEquals(
+                expected = 15,
+                actual = discount?.firstOrderDiscount,
+            )
+        }
+
+    @Test
+    fun `should prefer personal discount over company first-order discount`() =
+        runTest {
+            everySuspend { settingsRepo.getSettings() } returns settings(personalDiscountPercent = 15)
+            everySuspend {
+                orderRepository.getLastOrderByUserUuidLocalFirst()
+            } returns null
+            everySuspend { discountRepository.getDiscount() } returns Discount(10)
+
+            val discount = getDiscountUseCase()
+
+            assertEquals(
+                expected = 15,
+                actual = discount?.firstOrderDiscount,
+            )
+        }
+
+    @Test
+    fun `should return company discount when personalDiscountPercent is null and lastOrder is null`() =
+        runTest {
+            everySuspend { settingsRepo.getSettings() } returns settings(personalDiscountPercent = null)
+            everySuspend {
+                orderRepository.getLastOrderByUserUuidLocalFirst()
+            } returns null
+            everySuspend { discountRepository.getDiscount() } returns Discount(10)
+
+            val discount = getDiscountUseCase()
+
+            assertEquals(
+                expected = 10,
+                actual = discount?.firstOrderDiscount,
+            )
+        }
+
+    @Test
+    fun `should return null when personalDiscountPercent is null and lastOrder exists`() =
+        runTest {
+            everySuspend { settingsRepo.getSettings() } returns settings(personalDiscountPercent = null)
+            everySuspend {
+                orderRepository.getLastOrderByUserUuidLocalFirst()
+            } returns lightOrder()
+            everySuspend { discountRepository.getDiscount() } returns Discount(10)
+
+            val discount = getDiscountUseCase()
+
+            assertEquals(
+                expected = null,
+                actual = discount,
+            )
+        }
+
+    private fun settings(personalDiscountPercent: Int?) =
+        Settings(
+            userUuid = "userUuid",
+            phoneNumber = "+79001234567",
+            email = null,
+            personalDiscountPercent = personalDiscountPercent,
+        )
+
+    private fun lightOrder() =
+        LightOrder(
+            uuid = "uuid",
+            status = OrderStatus.DONE,
+            code = "code",
+            dateTime =
+                DateTime(
+                    date =
+                        Date(
+                            dayOfMonth = 5474,
+                            monthNumber = 7337,
+                            year = 1992,
+                        ),
+                    time = Time(hours = 3796, minutes = 8009),
+                ),
+        )
 }

--- a/shared/src/iosMain/kotlin/com/bunbeauty/shared/data/DataStoreRepository.kt
+++ b/shared/src/iosMain/kotlin/com/bunbeauty/shared/data/DataStoreRepository.kt
@@ -154,6 +154,14 @@ actual class DataStoreRepository :
                             .stringForKey(
                                 SETTINGS_EMAIL_KEY,
                             ).toString(),
+                    personalDiscountPercent =
+                        NSUserDefaults.standardUserDefaults
+                            .objectForKey(SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY)
+                            ?.let {
+                                NSUserDefaults.standardUserDefaults
+                                    .integerForKey(SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY)
+                                    .toInt()
+                            },
                 ),
             )
         }
@@ -167,6 +175,17 @@ actual class DataStoreRepository :
             SETTINGS_PHONE_NUMBER_KEY,
         )
         NSUserDefaults.standardUserDefaults.setObject(settings.email, SETTINGS_EMAIL_KEY)
+        val personalDiscountPercent = settings.personalDiscountPercent
+        if (personalDiscountPercent != null) {
+            NSUserDefaults.standardUserDefaults.setObject(
+                personalDiscountPercent,
+                SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY,
+            )
+        } else {
+            NSUserDefaults.standardUserDefaults.removeObjectForKey(
+                SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY,
+            )
+        }
     }
 
     actual override val recommendationMaxVisible: Flow<Int?> =
@@ -218,6 +237,7 @@ actual class DataStoreRepository :
         NSUserDefaults.standardUserDefaults.removeObjectForKey(SETTINGS_USER_UUID_KEY)
         NSUserDefaults.standardUserDefaults.removeObjectForKey(SETTINGS_PHONE_NUMBER_KEY)
         NSUserDefaults.standardUserDefaults.removeObjectForKey(SETTINGS_EMAIL_KEY)
+        NSUserDefaults.standardUserDefaults.removeObjectForKey(SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY)
     }
 
     companion object {
@@ -228,6 +248,8 @@ actual class DataStoreRepository :
         private const val SETTINGS_USER_UUID_KEY = "SETTINGS_USER_UUID_KEY"
         private const val SETTINGS_PHONE_NUMBER_KEY = "SETTINGS_PHONE_NUMBER_KEY"
         private const val SETTINGS_EMAIL_KEY = "SETTINGS_EMAIL_KEY"
+        private const val SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY =
+            "SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY"
         private const val SELECTED_PAYMENT_METHOD_UUID_KEY = "SELECTED_PAYMENT_METHOD_UUID_KEY"
         private const val WITHOUT_UTENSILS_KEY = "WITHOUT_UTENSILS_KEY"
         private const val FIRST_DISCOUNT_KEY = "FIRST_DISCOUNT_KEY"

--- a/shared/src/jsMain/kotlin/com/bunbeauty/shared/data/DataStoreRepository.kt
+++ b/shared/src/jsMain/kotlin/com/bunbeauty/shared/data/DataStoreRepository.kt
@@ -48,12 +48,19 @@ actual class DataStoreRepository :
             userUuid = lsGet(SETTINGS_USER_UUID_KEY).orEmpty(),
             phoneNumber = lsGet(SETTINGS_PHONE_NUMBER_KEY).orEmpty(),
             email = lsGet(SETTINGS_EMAIL_KEY),
+            personalDiscountPercent = lsGet(SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY)?.toIntOrNull(),
         )
 
     actual override suspend fun saveSettings(settings: Settings) {
         lsSet(SETTINGS_USER_UUID_KEY, settings.userUuid)
         lsSet(SETTINGS_PHONE_NUMBER_KEY, settings.phoneNumber)
         lsSet(SETTINGS_EMAIL_KEY, settings.email.orEmpty())
+        val personalDiscountPercent = settings.personalDiscountPercent
+        if (personalDiscountPercent != null) {
+            lsSet(SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY, personalDiscountPercent.toString())
+        } else {
+            lsRemove(SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY)
+        }
     }
 
     actual override val selectedPaymentMethodUuid: Flow<String?> =
@@ -103,6 +110,7 @@ actual class DataStoreRepository :
         lsRemove(SETTINGS_USER_UUID_KEY)
         lsRemove(SETTINGS_PHONE_NUMBER_KEY)
         lsRemove(SETTINGS_EMAIL_KEY)
+        lsRemove(SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY)
         clearWithoutUtensils()
     }
 
@@ -154,6 +162,8 @@ actual class DataStoreRepository :
         private const val SETTINGS_USER_UUID_KEY = "SETTINGS_USER_UUID_KEY"
         private const val SETTINGS_PHONE_NUMBER_KEY = "SETTINGS_PHONE_NUMBER_KEY"
         private const val SETTINGS_EMAIL_KEY = "SETTINGS_EMAIL_KEY"
+        private const val SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY =
+            "SETTINGS_PERSONAL_DISCOUNT_PERCENT_KEY"
         private const val SELECTED_PAYMENT_METHOD_UUID_KEY = "SELECTED_PAYMENT_METHOD_UUID_KEY"
         private const val WITHOUT_UTENSILS_KEY = "WITHOUT_UTENSILS_KEY"
         private const val FIRST_DISCOUNT_KEY = "FIRST_DISCOUNT_KEY"


### PR DESCRIPTION
## Summary
- Read `personalDiscountPercent` from `GET /client/settings` (Settings → DataStore)
- Resolve effective discount in `GetDiscountUseCase`: personal > company first-order > null; reuse `Discount.firstOrderDiscount` for menu/cart UI
- Refresh settings after successful create-order and before menu discount resolve so stale personal % does not linger

## Test plan
- [ ] Menu shows personal discount % when set on backend
- [ ] Cart/create-order totals apply the same %
- [ ] After placing an order, personal % disappears from UI
- [ ] Without personal discount, first-order company discount still works as before
