### PR TITLE
Fix iOS TestFlight upload missing compose-resources

### DIFF
--- a/.github/workflows/publish-workflow-ios.yml
+++ b/.github/workflows/publish-workflow-ios.yml
@@ -198,9 +198,9 @@ jobs:
       - name: Install CocoaPods
         run: sudo gem install cocoapods
 
-      # Compose resources must exist (even empty) before `pod install`, otherwise
-      # CocoaPods skips registering them and the IPA ships without compose-resources →
-      # MissingResourceException on first Compose frame (splash logo / strings).
+      # Create the CMP CocoaPods resources dir before `pod install` (podspec path).
+      # An empty dir is still ignored by CocoaPods — the IPA copy is done in
+      # iosApp/Podfile post_install after [CP-User] Build shared fills this folder.
       - name: Prepare Compose CocoaPods resources dir
         working-directory: .
         run: mkdir -p shared/build/compose/cocoapods/compose-resources

--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -74,10 +74,55 @@ end
 
 # KMP only has iosSimulatorArm64 — Release fat archives pass ARCHS="arm64 x86_64"
 # into [CP-User] Build shared and fail with: Unknown iOS simulator arch: 'x86_64'
+#
+# Compose Multiplatform writes spec.resources = ['build/compose/cocoapods/compose-resources'].
+# CocoaPods expands that path at `pod install` and skips an empty/missing directory, so
+# [CP] Copy Pods Resources never ships compose-resources (MissingResourceException at launch).
+# Gradle fills the directory later in [CP-User] Build shared. post_install injects a copy
+# into each app's Pods-*-resources.sh so xcodebuild copies the filled folder into the .app.
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'x86_64'
     end
+  end
+
+  compose_copy_marker = 'Copy Compose Multiplatform resources'
+  resources_scripts = Dir.glob(
+    File.join(installer.sandbox.root.to_s, 'Target Support Files', 'Pods-*', 'Pods-*-resources.sh')
+  )
+  patched = 0
+  resources_scripts.each do |script_path|
+    contents = File.read(script_path)
+    next if contents.include?(compose_copy_marker)
+
+    contents << <<~'SH'
+
+      # Copy Compose Multiplatform resources
+      COMPOSE_RES="${PODS_ROOT}/../../shared/build/compose/cocoapods/compose-resources"
+      if [ ! -d "${COMPOSE_RES}" ]; then
+        echo "error: missing Compose resources dir: ${COMPOSE_RES}" >&2
+        exit 1
+      fi
+      if [ -z "$(find "${COMPOSE_RES}" -type f -print -quit)" ]; then
+        echo "error: Compose resources dir is empty: ${COMPOSE_RES}. Check [CP-User] Build shared / syncPodComposeResourcesForIos." >&2
+        exit 1
+      fi
+      copy_compose_mp_resources() {
+        dest="$1/compose-resources"
+        echo "Copy Compose Multiplatform resources -> ${dest}"
+        mkdir -p "${dest}"
+        rsync -a --delete "${COMPOSE_RES}/" "${dest}/"
+      }
+      copy_compose_mp_resources "${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+      if [ "${ACTION}" = "install" ] && [ "${SKIP_INSTALL}" = "NO" ]; then
+        copy_compose_mp_resources "${INSTALL_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+      fi
+    SH
+    File.write(script_path, contents)
+    patched += 1
+  end
+  if patched.zero? && resources_scripts.none? { |path| File.read(path).include?(compose_copy_marker) }
+    raise 'No Pods-*-resources.sh found to inject Compose resources copy'
   end
 end

--- a/iosApp/fastlane/Fastfile
+++ b/iosApp/fastlane/Fastfile
@@ -297,8 +297,10 @@ platform :ios do
       if sample.nil?
         UI.user_error!(
           "В #{File.basename(app_dir)} нет compose-resources. " \
-          "Проверьте shared.podspec (spec.resources) и что каталог " \
-          "shared/build/compose/cocoapods/compose-resources существовал до pod install."
+          "CocoaPods пропускает пустой spec.resources на pod install; копирование " \
+          "делает iosApp/Podfile post_install после [CP-User] Build shared. " \
+          "Проверьте, что shared/build/compose/cocoapods/compose-resources заполнен " \
+          "во время xcodebuild и что post_install дописал *-resources.sh."
         )
       end
       UI.success("compose-resources OK (пример: #{sample.sub("#{app_dir}/", '')})")


### PR DESCRIPTION
## Summary
GitHub Actions [run 31743205093](https://github.com/xidealo/PapaKarlo/actions/runs/31743205093) (master upload #67) failed: all 12 iOS IPAs shipped without compose-resources, so the app would crash on first Compose frame (MissingResourceException).

CocoaPods expands spec.resources at pod install. The compose-resources directory is empty then, so CocoaPods skips it. Gradle fills the folder later in [CP-User] Build shared, which is too late for [CP] Copy Pods Resources.

## Changes
- iosApp/Podfile post_install injects a copy into each Pods-*-resources.sh so xcodebuild copies the filled folder into the .app.
- Workflow comment updated to match this (empty dir before pod install is not enough).
- Fastlane IPA check error text points at the new copy path.

## Test plan
- Merge the **master hotfix PR** (this change only; do not merge develop into master).
- Re-run **Publish workflow ios (upload)** on master (push or workflow_dispatch).
- Confirm each IPA contains Payload/*.app/compose-resources (fastlane assertion should pass).