### PR TITLE
Fix last_order 404 Crashlytics noise and splash startup crash

### DIFF
--- a/app/src/main/java/com/bunbeauty/papakarlo/feature/main/MainActivity.kt
+++ b/app/src/main/java/com/bunbeauty/papakarlo/feature/main/MainActivity.kt
@@ -48,6 +48,8 @@ class MainActivity :
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
         enableEdgeToEdge(
             navigationBarStyle =
                 if (isDarkTheme()) {
@@ -61,7 +63,6 @@ class MainActivity :
                     )
                 },
         )
-        super.onCreate(savedInstanceState)
 
         setContent {
             val color = FoodDeliveryTheme.colors.mainColors.surface

--- a/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/network/api/NetworkConnectorImpl.kt
+++ b/shared/src/commonMain/kotlin/com/bunbeauty/shared/data/network/api/NetworkConnectorImpl.kt
@@ -55,6 +55,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.path
 import kotlinx.coroutines.flow.Flow
 import org.koin.core.component.KoinComponent
@@ -180,7 +181,7 @@ internal class NetworkConnectorImpl(
         )
 
     override suspend fun getLastOrder(token: String): ApiResult<LightOrderServer> =
-        getData(
+        getDataNotFoundAsNull(
             path = "v2/client/last_order",
             token = token,
         )
@@ -337,6 +338,44 @@ internal class NetworkConnectorImpl(
                     timeout = timeout,
                 )
             }
+        }
+
+    private suspend inline fun <reified R> getDataNotFoundAsNull(
+        path: String,
+        parameters: Map<String, Any> = mapOf(),
+        token: String? = null,
+        timeout: Long = COMMON_TIMEOUT,
+    ): ApiResult<R> =
+        try {
+            val response =
+                client.get {
+                    buildRequest(
+                        path = path,
+                        parameters = parameters,
+                        token = token,
+                        timeout = timeout,
+                    )
+                }
+            if (response.status == HttpStatusCode.NotFound) {
+                ApiResult.Success(null)
+            } else {
+                ApiResult.Success(response.body())
+            }
+        } catch (exception: FoodDeliveryNetworkException) {
+            throw exception
+        } catch (exception: ClientRequestException) {
+            if (exception.response.status == HttpStatusCode.NotFound) {
+                ApiResult.Success(null)
+            } else {
+                val code = exception.response.status.value
+                val message = exception.message
+                errorLogger.logWarning(code = code, message = message, throwable = exception)
+                ApiResult.Error(ApiError(code, message))
+            }
+        } catch (exception: Throwable) {
+            val message = exception.message.toString()
+            errorLogger.logWarning(code = 0, message = message, throwable = exception)
+            ApiResult.Error(ApiError(0, message))
         }
 
     private suspend inline fun <reified R> postData(


### PR DESCRIPTION
## Summary

Fixes two client bugs tracked in Trello:

- [Bug. 404 на last_order](https://trello.com/c/qryxna4j)
- [Bug. Crash splash_background](https://trello.com/c/CwGKrLwu)

### Bug 1: `last_order` HTTP 404 → Crashlytics noise

`GET v2/client/last_order` returns 404 when the user has no last order. Previously this was treated as an error and logged to Crashlytics.

**Fix:** Added `getDataNotFoundAsNull()` and switched `getLastOrder()` to use it. HTTP 404 now returns `ApiResult.Success(null)` without `recordException` / warning logging.

### Bug 2: Splash startup crash (`Resources$NotFoundException`)

`enableEdgeToEdge()` was called before `super.onCreate()`, which could crash on cold start when resolving splash/theme resources.

**Fix:** Call `super.onCreate(savedInstanceState)` first, then `enableEdgeToEdge()`.

## Files changed

- `shared/.../NetworkConnectorImpl.kt` — 404-as-null for `last_order`
- `app/.../MainActivity.kt` — `onCreate` order fix

## How to test

### Bug 1: last_order 404

1. Log in with an account **without orders** (or clear last order on backend).
2. Open the menu screen.
3. **Expected:** "Ваш заказ" block is hidden; no crash; no Crashlytics exception for 404.
4. **Optional:** With an account that has a last order — block shows normally, API returns data.

### Bug 2: Splash cold start

1. Force-stop the app.
2. Cold start in **light theme** — splash shows, app launches without crash.
3. Cold start in **dark theme** — same.
4. **Expected:** No `Resources$NotFoundException` / FATAL in logcat.

## QA report (2026-09-02)

| Bug | Result |
|-----|--------|
| Splash crash | **PASS** — light/dark cold start OK |
| last_order 404 | **PARTIAL** — code verified; test account `9999999901` has order Э-09, 404 scenario not reproduced |

Full report: `.cursor/test-reports/2026-09-02_bugfixes-client/report.md`